### PR TITLE
fix: Add presentation record to OID4VC request

### DIFF
--- a/oid4vc/oid4vc/routes.py
+++ b/oid4vc/oid4vc/routes.py
@@ -707,6 +707,12 @@ class CreateOID4VPReqResponseSchema(OpenAPISchema):
         metadata={"descripton": "The created request"},
     )
 
+    presentation = fields.Nested(
+        OID4VPPresentationSchema,
+        required=True,
+        metadata={"descripton": "The created presentation"},
+    )
+
 
 class CreateOID4VPReqRequestSchema(OpenAPISchema):
     """Request schema for creating an OID4VP Request."""
@@ -759,6 +765,7 @@ async def create_oid4vp_request(request: web.Request):
         {
             "request_uri": full_uri,
             "request": req_record.serialize(),
+            "presentation": pres_record.serialize(),
         }
     )
 


### PR DESCRIPTION
The Presentation Record that is created during an OID4VC Presentation Request is never presented back to the requester, so there is no way for them to retrieve the ID for future lookups. Due to this oversight, I've added it to the response.

cc: @dbluhm 