### PR TITLE
feat: Return the generated openid URLs for credential offers

### DIFF
--- a/oid4vc/demo/frontend/index.js
+++ b/oid4vc/demo/frontend/index.js
@@ -229,8 +229,7 @@ async function issue_jwt_credential(req, res) {
   // Generate QRCode and send it to the browser via HTMX events
   logger.info(JSON.stringify(offerResponse.data));
   logger.info(exchangeId);
-  const encodedJSON = encodeURIComponent(JSON.stringify(credentialOffer));
-  const qrcode = `openid-credential-offer://?credential_offer=${encodedJSON}`;
+  const qrcode = credentialOffer.offer_uri;
   events.emit(`issuance-${req.body.registrationId}`, {type: "message", message: `Sending offer to user: ${qrcode}`});
   events.emit(`issuance-${req.body.registrationId}`, {type: "qrcode", credentialOffer, exchangeId, qrcode});
   exchangeCache.set(exchangeId, { exchangeId, credentialOffer, did, supportedCredId, registrationId: req.body.registrationId });
@@ -412,8 +411,7 @@ async function issue_sdjwt_credential(req, res) {
   // Generate QRCode and send it to the browser via HTMX events
   logger.info(JSON.stringify(offerResponse.data));
   logger.info(exchangeId);
-  const encodedJSON = encodeURIComponent(JSON.stringify(credentialOffer));
-  const qrcode = `openid-credential-offer://?credential_offer=${encodedJSON}`;
+  const qrcode = credentialOffer.offer_uri;
   events.emit(`issuance-${req.body.registrationId}`, {type: "message", message: `Sending offer to user: ${qrcode}`});
   events.emit(`issuance-${req.body.registrationId}`, {type: "qrcode", credentialOffer, exchangeId, qrcode});
   exchangeCache.set(exchangeId, { exchangeId, credentialOffer, did, supportedCredId, registrationId: req.body.registrationId });

--- a/oid4vc/integration/oid4vci_client/client.py
+++ b/oid4vc/integration/oid4vci_client/client.py
@@ -46,11 +46,12 @@ class CredentialOffer:
     @classmethod
     def from_dict(cls, value: dict):
         """Parse from dict."""
+        offer = value["offer"]
         return cls(
-            value["credential_issuer"],
-            value["credentials"],
-            value.get("grants", {}).get("authorization_code"),
-            CredentialGrantPreAuth.from_grants(value.get("grants", {})),
+            offer["credential_issuer"],
+            offer["credentials"],
+            offer.get("grants", {}).get("authorization_code"),
+            CredentialGrantPreAuth.from_grants(offer.get("grants", {})),
         )
 
 

--- a/oid4vc/oid4vc/routes.py
+++ b/oid4vc/oid4vc/routes.py
@@ -318,9 +318,22 @@ class CredOfferSchema(OpenAPISchema):
     grants = fields.Nested(CredOfferGrantSchema(), required=True)
 
 
+class CredOfferResponseSchema(OpenAPISchema):
+    """Credential Offer Schema."""
+
+    offer_uri = fields.Str(
+        required=True,
+        metadata={
+            "description": "The URL of the credential issuer.",
+            "example": "openid-credential-offer://...",
+        },
+    )
+    offer = fields.Nested(CredOfferSchema(), required=True)
+
+
 @docs(tags=["oid4vci"], summary="Get a credential offer")
 @querystring_schema(CredOfferQuerySchema())
-@response_schema(CredOfferSchema(), 200)
+@response_schema(CredOfferResponseSchema(), 200)
 @tenant_authentication
 async def get_cred_offer(request: web.BaseRequest):
     """Endpoint to retrieve an OpenID4VCI compliant offer.
@@ -357,8 +370,14 @@ async def get_cred_offer(request: web.BaseRequest):
             }
         },
     }
+    offer_uri = quote(json.dumps(offer))
+    full_uri = f"openid-credential-offer://?credential_offer={offer_uri}"
+    offer_response = {
+        "offer": offer,
+        "offer_uri": full_uri,
+    }
 
-    return web.json_response(offer)
+    return web.json_response(offer_response)
 
 
 class SupportedCredCreateRequestSchema(OpenAPISchema):


### PR DESCRIPTION
Instead of forcing the consumer to generate the URI themselves, it would be handy to generate it for them.

cc: @dbluhm 