### PR TITLE
Prevent workflows running on forks

### DIFF
--- a/.github/workflows/create-release-pr.yaml
+++ b/.github/workflows/create-release-pr.yaml
@@ -19,6 +19,7 @@ jobs:
       contents: write
       pull-requests: write
     runs-on: ubuntu-latest
+    if: github.repository == 'openwallet-foundation/acapy-plugins'
     outputs:
       current_available_version: ${{ steps.current_available_version.outputs.version }}
       current_global_version: ${{ steps.current_global_version.outputs.version }}

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -11,6 +11,7 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    if: github.repository == 'openwallet-foundation/acapy-plugins'
     outputs:
       current_global_version: ${{ steps.current_global_version.outputs.version }}
       should_create_release: ${{ steps.should_create_release.outputs.should_create_release }}

--- a/.github/workflows/pr-integration-tests.yaml
+++ b/.github/workflows/pr-integration-tests.yaml
@@ -13,6 +13,7 @@ jobs:
   integration-tests:
     name: "Integration Tests"
     runs-on: ubuntu-latest
+    if: (github.repository == 'openwallet-foundation/acapy-plugins') && ((github.event_name == 'pull_request' && github.event.pull_request.draft == false) || (github.event_name != 'pull_request'))
     steps:
       #----------------------------------------------
       #       Check out repo

--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -12,6 +12,7 @@ permissions:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: github.repository == 'openwallet-foundation/acapy-plugins'
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Only run selected workflows on the openwallet-foundation repo.

Only run integration tests on draft = false PR's

Still runs linting and unit tests on forks. 