### PR TITLE
OID4VC: Verify KB-JWT

### DIFF
--- a/oid4vc/demo/frontend/index.js
+++ b/oid4vc/demo/frontend/index.js
@@ -268,69 +268,73 @@ async function issue_sdjwt_credential(req, res) {
 
 
   // Create credential schema
-  const createCredentialSupportedUrl = `${API_BASE_URL}/oid4vci/credential-supported/create/sd-jwt`;
+  const createCredentialSupportedUrl = `${API_BASE_URL}/oid4vci/credential-supported/create`;
   const createCredentialSupportedOptions = {
     method: "POST",
     headers: commonHeaders,
     body: JSON.stringify({
       format: "vc+sd-jwt",
       id: "IDCard",
-      cryptographic_binding_methods_supported: ["jwk"],
-      display: [
-        {
-          "name": "ID Card",
-          "locale": "en-US",
-          "background_color": "#12107c",
-          "text_color": "#FFFFFF"
-        }
-      ],
-      vct: "ExampleIDCard",
-      "claims": {
-        "given_name": {
-          "mandatory": true,
-          "value_type": "string",
+      format_data: {
+        cryptographic_binding_methods_supported: ["jwk"],
+        display: [
+          {
+            "name": "ID Card",
+            "locale": "en-US",
+            "background_color": "#12107c",
+            "text_color": "#FFFFFF"
+          }
+        ],
+        vct: "ExampleIDCard",
+        "claims": {
+          "given_name": {
+            "mandatory": true,
+            "value_type": "string",
+          },
+          "family_name": {
+            "mandatory": true,
+            "value_type": "string",
+          },
+          "age_equal_or_over": {
+            "12": {
+              "mandatory": true,
+              "value_type": "boolean",
+            },
+            "14": {
+              "mandatory": true,
+              "value_type": "boolean",
+            },
+            "16": {
+              "mandatory": true,
+              "value_type": "boolean",
+            },
+            "18": {
+              "mandatory": true,
+              "value_type": "boolean",
+            },
+            "21": {
+              "mandatory": true,
+              "value_type": "boolean",
+            },
+            "65": {
+              "mandatory": true,
+              "value_type": "boolean",
+            },
+          }
         },
-        "family_name": {
-          "mandatory": true,
-          "value_type": "string",
-        },
-        "age_equal_or_over": {
-          "12": {
-            "mandatory": true,
-            "value_type": "boolean",
-          },
-          "14": {
-            "mandatory": true,
-            "value_type": "boolean",
-          },
-          "16": {
-            "mandatory": true,
-            "value_type": "boolean",
-          },
-          "18": {
-            "mandatory": true,
-            "value_type": "boolean",
-          },
-          "21": {
-            "mandatory": true,
-            "value_type": "boolean",
-          },
-          "65": {
-            "mandatory": true,
-            "value_type": "boolean",
-          },
-        }
       },
-      sd_list: [
-        "/given_name",
-        "/family_name",
-        "/age_equal_or_over/12",
-        "/age_equal_or_over/14",
-        "/age_equal_or_over/16",
-        "/age_equal_or_over/18",
-        "/age_equal_or_over/21",
-        "/age_equal_or_over/65"
-      ]
+      vc_additional_data: {
+        sd_list: [
+          "/given_name",
+          "/family_name",
+          "/age_equal_or_over/12",
+          "/age_equal_or_over/14",
+          "/age_equal_or_over/16",
+          "/age_equal_or_over/18",
+          "/age_equal_or_over/21",
+          "/age_equal_or_over/65"
+        ]
+      }
     }),
   };
 

--- a/oid4vc/oid4vc/models/presentation_definition.py
+++ b/oid4vc/oid4vc/models/presentation_definition.py
@@ -22,6 +22,7 @@ class OID4VPPresDef(BaseRecord):
         *,
         pres_def_id: Optional[str] = None,
         pres_def: Dict[str, Any],
+        nonce: Optional[str] = None,
         **kwargs,
     ) -> None:
         """Initialize an OID4VP Presentation instance."""
@@ -29,6 +30,7 @@ class OID4VPPresDef(BaseRecord):
         super().__init__(pres_def_id, **kwargs)
 
         self.pres_def = pres_def
+        self.nonce = nonce  # in request
 
     @property
     def pres_def_id(self) -> str:
@@ -61,4 +63,8 @@ class OID4VPPresDefSchema(BaseRecordSchema):
         metadata={
             "description": "Presentation definition",
         },
+    )
+
+    nonce = fields.Str(
+        required=False,
     )

--- a/oid4vc/sd_jwt_vc/cred_processor.py
+++ b/oid4vc/sd_jwt_vc/cred_processor.py
@@ -198,19 +198,19 @@ class SdJwtCredIssueProcessor(Issuer, CredVerifier, PresVerifier):
             raise ValueError(f"Invalid JSON pointer(s): {bad_pointer}")
 
     async def verify_presentation(
-        self, profile: Profile, presentation: Any
+        self, profile: Profile, presentation: Any, aud: Optional[str] = None, nonce: Optional[str] = None 
     ) -> VerifyResult:
         """Verify signature over credential or presentation."""
 
-        result = await sd_jwt_verify(profile, presentation)
+        result = await sd_jwt_verify(profile, presentation, aud, nonce)
         # TODO: This is a little hacky
         return VerifyResult(result.verified, presentation)
 
-    async def verify_credential(self, profile: Profile, credential: Any) -> VerifyResult:
+    async def verify_credential(self, profile: Profile, credential: Any, aud: Optional[str] = None, nonce: Optional[str] = None) -> VerifyResult:
         """Verify signature over credential."""
         # TODO: Can we optimize this? since we end up doing this twice in a row
 
-        result = await sd_jwt_verify(profile, credential)
+        result = await sd_jwt_verify(profile, credential, aud, nonce)
         return VerifyResult(result.verified, result.payload)
 
 


### PR DESCRIPTION
In an attempt to fix the issue raised in #1163, we should be storing the nonce generated for presentations then checking it later on. Now, we are storing it, then passing it down to the verification logic (along with the configured endpoint/client ID) to verify the KB-JWT.