### PR TITLE
Interop Test Fixes

### DIFF
--- a/oid4vc/integration/tests/test_interop/test_credo.py
+++ b/oid4vc/integration/tests/test_interop/test_credo.py
@@ -1,3 +1,4 @@
+from typing import Any, Dict
 from acapy_controller.controller import Controller
 import pytest
 
@@ -6,9 +7,9 @@ from credo_wrapper import CredoWrapper
 
 @pytest.mark.interop
 @pytest.mark.asyncio
-async def test_accept_credential_offer(credo: CredoWrapper, offer: str):
+async def test_accept_credential_offer(credo: CredoWrapper, offer: Dict[str, Any]):
     """Test OOB DIDExchange Protocol."""
-    await credo.openid4vci_accept_offer(offer)
+    await credo.openid4vci_accept_offer(offer["offer_uri"])
 
 
 @pytest.mark.interop
@@ -20,9 +21,11 @@ async def test_accept_credential_offer_sdjwt(credo: CredoWrapper, sdjwt_offer: s
 
 @pytest.mark.interop
 @pytest.mark.asyncio
-async def test_accept_auth_request(controller: Controller, credo: CredoWrapper, offer: str, request_uri: str):
+async def test_accept_auth_request(
+    controller: Controller, credo: CredoWrapper, offer: Dict[str, Any], request_uri: str
+):
     """Test OOB DIDExchange Protocol."""
-    await credo.openid4vci_accept_offer(offer)
+    await credo.openid4vci_accept_offer(offer["offer_uri"])
     await credo.openid4vp_accept_request(request_uri)
     await controller.event_with_values("oid4vp", state="presentation-valid")
 
@@ -30,7 +33,10 @@ async def test_accept_auth_request(controller: Controller, credo: CredoWrapper, 
 @pytest.mark.interop
 @pytest.mark.asyncio
 async def test_accept_sdjwt_auth_request(
-    controller: Controller, credo: CredoWrapper, sdjwt_offer: str, sdjwt_request_uri: str
+    controller: Controller,
+    credo: CredoWrapper,
+    sdjwt_offer: str,
+    sdjwt_request_uri: str,
 ):
     """Test OOB DIDExchange Protocol."""
     await credo.openid4vci_accept_offer(sdjwt_offer)

--- a/oid4vc/integration/tests/test_interop/test_sphereon.py
+++ b/oid4vc/integration/tests/test_interop/test_sphereon.py
@@ -1,3 +1,4 @@
+from typing import Any, Dict
 import pytest
 
 from sphereon_wrapper import SphereaonWrapper
@@ -16,6 +17,6 @@ async def test_api(sphereon: SphereaonWrapper):
 
 @pytest.mark.interop
 @pytest.mark.asyncio
-async def test_sphereon_pre_auth(sphereon: SphereaonWrapper, offer: str):
+async def test_sphereon_pre_auth(sphereon: SphereaonWrapper, offer: Dict[str, Any]):
     """Test receive offer for pre auth code flow."""
-    await sphereon.accept_credential_offer(offer)
+    await sphereon.accept_credential_offer(offer["offer_uri"])


### PR DESCRIPTION
I had missed a couple of changes in #1373 to make the both the interop tests and the integration tests happy with the same fixtures. 
Now the integration tests and the interop tests are both running properly. There might be a cleaner way to deal with this, but I'll leave that for the future for now