### PR TITLE
OID4VC: Bugfixes and API Updates

### DIFF
--- a/oid4vc/README.md
+++ b/oid4vc/README.md
@@ -193,7 +193,7 @@ The Plugin expects the following configuration options. These options can either
 
 ### Creating Supported Credential Records
 
-To issue a credential using OpenID4VCI, the Issuer must first prepare credential issuer metadata including which credentials the Issuer can issue. Below is an example payload to the `POST /oid4vci/credential-supported/create` endpoint:
+To issue a credential using OpenID4VCI, the Issuer must first prepare credential issuer metadata including which credentials the Issuer can issue. Below is an example payload to the `POST /oid4vci/credential-supported/create/jwt` endpoint:
 
 ```json
 {
@@ -216,56 +216,48 @@ To issue a credential using OpenID4VCI, the Issuer must first prepare credential
     }
   ],
   "format": "jwt_vc_json",
-  "format_data": {
-    "credentialSubject": {
-      "degree": {},
-      "given_name": {
-        "display": [
-          {
-            "name": "Given Name",
-            "locale": "en-US"
-          }
-        ]
-      },
-      "gpa": {
-        "display": [
-          {
-            "name": "GPA"
-          }
-        ]
-      },
-      "last_name": {
-        "display": [
-          {
-            "name": "Surname",
-            "locale": "en-US"
-          }
-        ]
-      }
+  "credentialSubject": {
+    "degree": {},
+    "given_name": {
+      "display": [
+        {
+          "name": "Given Name",
+          "locale": "en-US"
+        }
+      ]
     },
-    "types": [
-      "VerifiableCredential",
-      "UniversityDegreeCredential"
-    ]
+    "gpa": {
+      "display": [
+        {
+          "name": "GPA"
+        }
+      ]
+    },
+    "last_name": {
+      "display": [
+        {
+          "name": "Surname",
+          "locale": "en-US"
+        }
+      ]
+    }
   },
+  "type": [
+    "VerifiableCredential",
+    "UniversityDegreeCredential"
+  ],
   "id": "UniversityDegreeCredential",
-  "vc_additional_data": {
-    "@context": [
-      "https://www.w3.org/2018/credentials/v1",
-      "https://www.w3.org/2018/credentials/examples/v1"
-    ],
-    "type": [
-      "VerifiableCredential",
-      "UniversityDegreeCredential"
-    ]
-  }
+  "@context": [
+    "https://www.w3.org/2018/credentials/v1",
+    "https://www.w3.org/2018/credentials/examples/v1"
+  ],
 }
 ```
 
 For the `id`, `format`, `cryptographic_binding_supported`, `cryptographic_suites_supported`, and `display` attributes, see the [OpenID4VCI Specification, Section 10.2.3][oid4vci].
 
-- `format_data`: This attribute represents data specific to a given credential format. In this Supported Credential, which is of format `jwt_vc_json`, this includes `types` (required for JWT-VC) and `credentialSubject` (which represents display characteristics of the credential only and is not an exhaustive list of the credential attributes). These values are reported in the credential issuer metadata.
-- `vc_additional_data`: This attribute represents data that is included in all credentials of this type. In this Supported Credential, this includes the `@context` of credential to be issued as well as the `type`. These values are NOT reported in the credential issuer metadata.
+- `type` is a required attribute for JWT-VC (recorded as `types` in the `SupportedCredential.format_data` dictionary), and `credentialSubject` represents display characteristics of the credential only and is not an exhaustive list of the credential attributes. These values are reported in the credential issuer metadata.
+- The `@context` of credential to be issued, as well as the `type` are stored in the `SupportedCredential.vc_additional_data` dictionary. These values are NOT reported in the credential issuer metadata.
 
 When the Controller sets up a Supported Credential record using the Admin API, the holder, upon requesting Credential Issuer Metadata, will receive the following information in response:
 
@@ -356,9 +348,8 @@ poetry run pytest tests/
 This plugin includes two sets of integration tests:
 
 - Tests against a minimal OpenID4VCI Client written in Python
-- Tests against AFJ + OpenID4VCI Client Package (not complete!)
-
-AFJ has an active PR working on adding support for Draft 11 version of the OpenID4VCI specification. Until that PR is in and available in a release, these tests are incomplete and ignored.
+- Interop Tests against Credo and Sphereon
+  - The interop tests require an https endpoint, so they aren't run with the regular integration tests. See `integration/README.md` for instructions on running the interop tests
 
 To run the integration tests:
 
@@ -373,9 +364,8 @@ For Apple Silicon, the `DOCKER_DEFAULT_PLATFORM=linux/amd64` environment variabl
 
 ## Not Implemented
 
-- `ldp_vc`, `sd_jwt_vc`
+- `ldp_vc`
 - Authorization Code Flow
-- Only signature suite supported by ACA-Py for jwt-vc right now is `EdDSA`
 - GET /.well-known/openid-configuration
 - GET /.well-known/oauth-authorization-server
 - Batch Credential Issuance

--- a/oid4vc/integration/tests/conftest.py
+++ b/oid4vc/integration/tests/conftest.py
@@ -13,7 +13,7 @@ from oid4vci_client.client import OpenID4VCIClient
 ISSUER_ADMIN_ENDPOINT = getenv("ISSUER_ADMIN_ENDPOINT", "http://localhost:3001")
 
 
-@pytest_asyncio.fixture
+@pytest_asyncio.fixture(scope="session")
 async def controller():
     """Connect to Issuer."""
     controller = Controller(ISSUER_ADMIN_ENDPOINT)
@@ -27,7 +27,7 @@ def test_client():
     yield client
 
 
-@pytest_asyncio.fixture
+@pytest_asyncio.fixture(scope="session")
 async def issuer_did(controller: Controller):
     result = await controller.post(
         "/did/jwk/create",
@@ -40,7 +40,7 @@ async def issuer_did(controller: Controller):
     yield did
 
 
-@pytest_asyncio.fixture
+@pytest_asyncio.fixture(scope="session")
 async def supported_cred_id(controller: Controller, issuer_did: str):
     """Create a supported credential."""
     supported = await controller.post(
@@ -78,6 +78,7 @@ async def offer(controller: Controller, issuer_did: str, supported_cred_id: str)
     )
     yield offer
 
+
 @pytest_asyncio.fixture
 async def offer_by_ref(controller: Controller, issuer_did: str, supported_cred_id: str):
     """Create a credential offer."""
@@ -98,9 +99,7 @@ async def offer_by_ref(controller: Controller, issuer_did: str, supported_cred_i
 
     offer_ref = urlparse(offer_ref_full["credential_offer_uri"])
     offer_ref = parse_qs(offer_ref.query)["credential_offer"][0]
-    async with ClientSession(
-        headers=controller.headers
-    ) as session:
+    async with ClientSession(headers=controller.headers) as session:
         async with session.request(
             "GET", url=offer_ref, params=exchange_param, headers=controller.headers
         ) as offer:
@@ -244,9 +243,7 @@ async def sdjwt_offer_by_ref(
 
     offer_ref = urlparse(offer_ref_full["credential_offer_uri"])
     offer_ref = parse_qs(offer_ref.query)["credential_offer"][0]
-    async with ClientSession(
-        headers=controller.headers
-    ) as session:
+    async with ClientSession(headers=controller.headers) as session:
         async with session.request(
             "GET", url=offer_ref, params=exchange_param, headers=controller.headers
         ) as offer:

--- a/oid4vc/oid4vc/public_routes.py
+++ b/oid4vc/oid4vc/public_routes.py
@@ -460,6 +460,8 @@ async def get_request(request: web.Request):
     """Get an OID4VP Request token."""
     context: AdminRequestContext = request["context"]
     request_id = request.match_info["request_id"]
+    pres_def = None
+    dcql_query = None
 
     try:
         async with context.session() as session:
@@ -520,9 +522,9 @@ async def get_request(request: web.Request):
         "response_mode": "direct_post",
         "scope": "vp_token",
     }
-    if pres_def:
+    if pres_def is not None:
         payload["presentation_definition"] = pres_def.pres_def
-    if dcql_query:
+    if dcql_query is not None:
         payload["dcql_query"] = dcql_query.record_value
 
     headers = {

--- a/oid4vc/oid4vc/routes.py
+++ b/oid4vc/oid4vc/routes.py
@@ -552,6 +552,13 @@ async def supported_credential_create(request: web.Request):
     LOGGER.info(f"body: {body}")
     body["identifier"] = body.pop("id")
 
+    format_data: dict = body.get("format_data", {})
+    if format_data.get("vct") and format_data.get("types"):
+        raise web.HTTPBadRequest(
+            reason="Cannot have both `vct` and `types`. "
+            "`vct` is for SD JWT and `types` is for JWT VC"
+        )
+
     record = SupportedCredential(
         **body,
     )

--- a/oid4vc/oid4vc/routes.py
+++ b/oid4vc/oid4vc/routes.py
@@ -1798,22 +1798,35 @@ async def register(app: web.Application):
                 supported_credential_list,
                 allow_head=False,
             ),
+            web.get(
+                "/oid4vci/credential-supported/records/{supported_cred_id}",
+                get_supported_credential_by_id,
+            ),
+            web.put(
+                "/oid4vci/credential-supported/records/jwt/{supported_cred_id}",
+                update_supported_credential_jwt_vc,
+            ),
             web.delete(
-                "/oid4vci/exchange-supported/records/{supported_cred_id}",
+                "/oid4vci/credential-supported/records/jwt/{supported_cred_id}",
                 supported_credential_remove,
             ),
             web.post("/oid4vp/request", create_oid4vp_request),
+            web.get("/oid4vp/requests", list_oid4vp_requests),
+            web.get("/oid4vp/request/{request_id}", get_oid4vp_request_by_id),
             web.post("/oid4vp/presentation-definition", create_oid4vp_pres_def),
             web.get("/oid4vp/presentation-definitions", list_oid4vp_pres_defs),
             web.get(
                 "/oid4vp/presentation-definition/{pres_def_id}",
                 get_oid4vp_pres_def_by_id,
             ),
+            web.put(
+                "/oid4vp/presentation-definition/{pres_def_id}", update_oid4vp_pres_def
+            ),
             web.delete(
                 "/oid4vp/presentation-definition/{pres_def_id}", oid4vp_pres_def_remove
             ),
             web.get("/oid4vp/presentations", list_oid4vp_presentations),
-            web.get("/oid4vp/presentation/{request_id}", get_oid4vp_pres_by_id),
+            web.get("/oid4vp/presentation/{presentation_id}", get_oid4vp_pres_by_id),
             web.delete("/oid4vp/presentation/{presentation_id}", oid4vp_pres_remove),
             web.post("/oid4vp/dcql/queries", create_dcql_query),
             web.get("/oid4vp/dcql/queries", list_dcql_queries),

--- a/oid4vc/sd_jwt_vc/routes.py
+++ b/oid4vc/sd_jwt_vc/routes.py
@@ -23,6 +23,7 @@ from marshmallow import fields
 from oid4vc.cred_processor import CredProcessors
 
 from oid4vc.models.supported_cred import SupportedCredential, SupportedCredentialSchema
+from oid4vc.routes import supported_cred_is_unique
 
 
 LOGGER = logging.getLogger(__name__)
@@ -150,6 +151,11 @@ async def supported_credential_create(request: web.Request):
     profile = context.profile
 
     body: Dict[str, Any] = await request.json()
+
+    if not await supported_cred_is_unique(body["id"], profile):
+        raise web.HTTPBadRequest(
+            reason=f"Record with identifier {body["id"]} already exists."
+        )
     LOGGER.info(f"body: {body}")
     body["identifier"] = body.pop("id")
     format_data = {}

--- a/oid4vc/sd_jwt_vc/routes.py
+++ b/oid4vc/sd_jwt_vc/routes.py
@@ -7,11 +7,15 @@ from textwrap import dedent
 from aiohttp import web
 from aiohttp_apispec import (
     docs,
+    match_info_schema,
     request_schema,
     response_schema,
 )
 from acapy_agent.admin.decorators.auth import tenant_authentication
 from acapy_agent.admin.request_context import AdminRequestContext
+from acapy_agent.askar.profile import AskarProfileSession
+from acapy_agent.storage.error import StorageError, StorageNotFoundError
+from acapy_agent.messaging.models.base import BaseModelError
 from acapy_agent.messaging.models.openapi import OpenAPISchema
 from marshmallow import fields
 
@@ -121,7 +125,7 @@ class SdJwtSupportedCredCreateReq(OpenAPISchema):
                 "/is_over_18",
                 "/is_over_21",
                 "/is_over_65",
-            ]
+            ],
         },
     )
 
@@ -180,12 +184,108 @@ async def supported_credential_create(request: web.Request):
     return web.json_response(record.serialize())
 
 
+class SupportedCredentialMatchSchema(OpenAPISchema):
+    """Match info for request taking credential supported id."""
+
+    supported_cred_id = fields.Str(
+        required=True,
+        metadata={
+            "description": "Credential supported identifier",
+        },
+    )
+
+
+async def supported_cred_update_helper(
+    record: SupportedCredential,
+    body: Dict[str, Any],
+    session: AskarProfileSession,
+) -> SupportedCredential:
+    """Helper method for updating a JWT Supported Credential Record."""
+    format_data = {}
+    vc_additional_data = {}
+
+    body["identifier"] = body.pop("id")
+
+    format_data["vct"] = body.pop("vct")
+    format_data["claims"] = body.pop("claims", None)
+    format_data["order"] = body.pop("order", None)
+    vc_additional_data["sd_list"] = body.pop("sd_list", None)
+
+    record.identifier = body["id"]
+    record.format = body["format"]
+    record.cryptographic_binding_methods_supported = body.get(
+        "cryptographic_binding_methods_supported", None
+    )
+    record.cryptographic_suites_supported = body.get(
+        "cryptographic_suites_supported", None
+    )
+    record.display = body.get("display", None)
+    record.format_data = format_data
+    record.vc_additional_data = vc_additional_data
+
+    await record.save(session)
+    return record
+
+
+@docs(
+    tags=["oid4vci"],
+    summary="Update a Supported Credential. "
+    "Expected to be a complete replacement of an SD JWT Supported Credential record, "
+    "i.e., optional values that aren't supplied will be `None`, rather than retaining "
+    "their original value.",
+)
+@match_info_schema(SupportedCredentialMatchSchema())
+@request_schema(SdJwtSupportedCredCreateReq())
+@response_schema(SupportedCredentialSchema())
+async def update_supported_credential_sd_jwt(request: web.Request):
+    """Update a JWT Supported Credential record."""
+
+    context: AdminRequestContext = request["context"]
+    body: Dict[str, Any] = await request.json()
+    supported_cred_id = request.match_info["supported_cred_id"]
+
+    LOGGER.info(f"body: {body}")
+    try:
+        async with context.session() as session:
+            record = await SupportedCredential.retrieve_by_id(
+                session, supported_cred_id
+            )
+
+            assert isinstance(session, AskarProfileSession)
+            record = await supported_cred_update_helper(record, body, session)
+
+    except StorageNotFoundError as err:
+        raise web.HTTPNotFound(reason=err.roll_up) from err
+    except (StorageError, BaseModelError) as err:
+        raise web.HTTPBadRequest(reason=err.roll_up) from err
+
+    registered_processors = context.inject(CredProcessors)
+    if record.format not in registered_processors.issuers:
+        raise web.HTTPBadRequest(
+            reason=f"Format {record.format} is not supported by"
+            " currently registered processors"
+        )
+
+    processor = registered_processors.issuer_for_format(record.format)
+    try:
+        processor.validate_supported_credential(record)
+    except ValueError as err:
+        raise web.HTTPBadRequest(reason=str(err)) from err
+
+    return web.json_response(record.serialize())
+
+
 async def register(app: web.Application):
     """Register routes."""
     app.add_routes(
         [
             web.post(
-                "/oid4vci/credential-supported/create/sd-jwt", supported_credential_create
+                "/oid4vci/credential-supported/create/sd-jwt",
+                supported_credential_create,
+            ),
+            web.put(
+                "/oid4vci/credential-supported/records/sd-jwt/{supported_cred_id}",
+                update_supported_credential_sd_jwt,
             ),
         ]
     )


### PR DESCRIPTION
This PR includes a number of somewhat miscellaneous updates and fixes for the OID4VC plugin.
Some highlights:
- Fix the bug reported in #1543 
- Fix the Credential Supported recreation reported in #1446 
- Add ability to patch `PresDef` and `SupportedCredential` records (#1443)
  - As a note, these new `PUT` endpoints perform a complete overwrite of the existing record, meaning that any optional attributes that aren't supplied in the new request will be `None`, rather than maintaining whatever value they were previously
- Some README updates are included (#1429)
  - @dbluhm were there other specific updates you were looking to see? 
- Better checking on the "generic" `/supported-credential/create` endpoint
  - some values are expected to only be present for specific formats, and shouldn't both be present at the same time, so we now perform some collision checking there. It didn't *break* anything to allow both attributes, but it could get confusing for debugging/analysis purposes