### PR TITLE
:construction_worker: Use python3.12-bookworm

### DIFF
--- a/basicmessage_storage/.devcontainer/devcontainer.json
+++ b/basicmessage_storage/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     "context": "..",
     "args": {
-      "VARIANT": "3.12-bullseye",
+      "VARIANT": "3.12-bookworm",
       "POETRY_VERSION": "1.8.3"
     }
   },

--- a/basicmessage_storage/docker/Dockerfile
+++ b/basicmessage_storage/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS base
+FROM python:3.12-slim-bookworm AS base
 WORKDIR /usr/src/app
 
 # Install and configure poetry
@@ -19,7 +19,7 @@ ARG install_flags='--with integration --extras aca-py'
 RUN poetry install ${install_flags}
 USER $user
 
-FROM python:3.12-bullseye
+FROM python:3.12-bookworm
 WORKDIR /usr/src/app
 COPY --from=base /usr/src/app/.venv /usr/src/app/.venv
 ENV PATH="/usr/src/app/.venv/bin:$PATH"

--- a/basicmessage_storage/integration/Dockerfile.test.runner
+++ b/basicmessage_storage/integration/Dockerfile.test.runner
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 WORKDIR /usr/src/app
 
 # install poetry

--- a/cheqd/.devcontainer/devcontainer.json
+++ b/cheqd/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     "context": "..",
     "args": {
-      "VARIANT": "3.12-bullseye",
+      "VARIANT": "3.12-bookworm",
       "POETRY_VERSION": "1.8.3"
     }
   },

--- a/cheqd/docker/Dockerfile
+++ b/cheqd/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS base
+FROM python:3.12-slim-bookworm AS base
 WORKDIR /usr/src/app
 
 # Install and configure poetry
@@ -19,7 +19,7 @@ ARG install_flags='--with integration --extras aca-py'
 RUN poetry install ${install_flags}
 USER $user
 
-FROM python:3.12-bullseye
+FROM python:3.12-bookworm
 WORKDIR /usr/src/app
 COPY --from=base /usr/src/app/.venv /usr/src/app/.venv
 ENV PATH="/usr/src/app/.venv/bin:$PATH"

--- a/cheqd/integration/Dockerfile.test.runner
+++ b/cheqd/integration/Dockerfile.test.runner
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 WORKDIR /usr/src/app
 
 # install poetry

--- a/connection_update/.devcontainer/devcontainer.json
+++ b/connection_update/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     "context": "..",
     "args": {
-      "VARIANT": "3.12-bullseye",
+      "VARIANT": "3.12-bookworm",
       "POETRY_VERSION": "1.8.3"
     }
   },

--- a/connection_update/docker/Dockerfile
+++ b/connection_update/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS base
+FROM python:3.12-slim-bookworm AS base
 WORKDIR /usr/src/app
 
 # Install and configure poetry
@@ -19,7 +19,7 @@ ARG install_flags='--with integration --extras aca-py'
 RUN poetry install ${install_flags}
 USER $user
 
-FROM python:3.12-bullseye
+FROM python:3.12-bookworm
 WORKDIR /usr/src/app
 COPY --from=base /usr/src/app/.venv /usr/src/app/.venv
 ENV PATH="/usr/src/app/.venv/bin:$PATH"

--- a/connection_update/integration/Dockerfile.test.runner
+++ b/connection_update/integration/Dockerfile.test.runner
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 WORKDIR /usr/src/app
 
 # install poetry

--- a/connections/.devcontainer/devcontainer.json
+++ b/connections/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     "context": "..",
     "args": {
-      "VARIANT": "3.12-bullseye",
+      "VARIANT": "3.12-bookworm",
       "POETRY_VERSION": "1.8.3"
     }
   },

--- a/firebase_push_notifications/.devcontainer/devcontainer.json
+++ b/firebase_push_notifications/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     "context": "..",
     "args": {
-      "VARIANT": "3.12-bullseye",
+      "VARIANT": "3.12-bookworm",
       "POETRY_VERSION": "1.8.3"
     }
   },

--- a/firebase_push_notifications/docker/Dockerfile
+++ b/firebase_push_notifications/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS base
+FROM python:3.12-slim-bookworm AS base
 WORKDIR /usr/src/app
 
 # Install and configure poetry
@@ -19,7 +19,7 @@ ARG install_flags='--with integration --extras aca-py'
 RUN poetry install ${install_flags}
 USER $user
 
-FROM python:3.12-bullseye
+FROM python:3.12-bookworm
 WORKDIR /usr/src/app
 COPY --from=base /usr/src/app/.venv /usr/src/app/.venv
 ENV PATH="/usr/src/app/.venv/bin:$PATH"

--- a/firebase_push_notifications/integration/Dockerfile.test.runner
+++ b/firebase_push_notifications/integration/Dockerfile.test.runner
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 WORKDIR /usr/src/app
 
 # install poetry

--- a/hedera/.devcontainer/devcontainer.json
+++ b/hedera/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     "context": "..",
     "args": {
-      "VARIANT": "3.12-bullseye",
+      "VARIANT": "3.12-bookworm",
       "POETRY_VERSION": "1.8.3"
     }
   },

--- a/hedera/docker/Dockerfile
+++ b/hedera/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bullseye AS base
+FROM python:3.12-slim-bookworm AS base
 
 ARG GITHUB_TOKEN
 
@@ -26,7 +26,7 @@ RUN poetry install --without dev --with integration --all-extras \
 
 USER $user
 
-FROM python:3.12-bullseye
+FROM python:3.12-bookworm
 
 WORKDIR /usr/src/app
 COPY --from=base /usr/src/app/.venv /usr/src/app/.venv

--- a/hedera/docker/Dockerfile.holder
+++ b/hedera/docker/Dockerfile.holder
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bullseye AS base
+FROM python:3.12-slim-bookworm AS base
 
 WORKDIR /usr/src
 

--- a/hedera/docker/Dockerfile.issuer
+++ b/hedera/docker/Dockerfile.issuer
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bullseye AS base
+FROM python:3.12-slim-bookworm AS base
 
 WORKDIR /usr/src
 

--- a/hedera/integration/Dockerfile.test.runner
+++ b/hedera/integration/Dockerfile.test.runner
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 WORKDIR /usr/src/app
 
 # install poetry

--- a/multitenant_provider/.devcontainer/devcontainer.json
+++ b/multitenant_provider/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     "context": "..",
     "args": {
-      "VARIANT": "3.12-bullseye",
+      "VARIANT": "3.12-bookworm",
       "POETRY_VERSION": "1.8.3"
     }
   },

--- a/multitenant_provider/docker/Dockerfile
+++ b/multitenant_provider/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS base
+FROM python:3.12-slim-bookworm AS base
 WORKDIR /usr/src/app
 
 # Install and configure poetry
@@ -23,7 +23,7 @@ ARG install_flags='--with integration --extras aca-py'
 RUN poetry install ${install_flags}
 USER $user
 
-FROM python:3.12-bullseye
+FROM python:3.12-bookworm
 WORKDIR /usr/src/app
 COPY --from=base /usr/src/app/.venv /usr/src/app/.venv
 ENV PATH="/usr/src/app/.venv/bin:$PATH"

--- a/multitenant_provider/integration/Dockerfile.test.runner
+++ b/multitenant_provider/integration/Dockerfile.test.runner
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 WORKDIR /usr/src/app
 
 # install poetry

--- a/oid4vc/.devcontainer/devcontainer.json
+++ b/oid4vc/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     "context": "..",
     "args": {
-      "VARIANT": "3.12-bullseye",
+      "VARIANT": "3.12-bookworm",
       "POETRY_VERSION": "1.8.3"
     }
   },

--- a/oid4vc/docker/Dockerfile
+++ b/oid4vc/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bullseye AS base
+FROM python:3.12-slim-bookworm AS base
 WORKDIR /usr/src/app
 
 # Install and configure poetry
@@ -23,7 +23,7 @@ COPY pyproject.toml poetry.lock README.md ./
 RUN poetry install --without dev --all-extras
 USER $user
 
-FROM python:3.12-bullseye
+FROM python:3.12-bookworm
 
 WORKDIR /usr/src/app
 COPY --from=base /usr/src/app/.venv /usr/src/app/.venv

--- a/plugin_globals/.devcontainer/devcontainer.json
+++ b/plugin_globals/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     "context": "..",
     "args": {
-      "VARIANT": "3.12-bullseye",
+      "VARIANT": "3.12-bookworm",
       "POETRY_VERSION": "1.8.3"
     }
   },

--- a/redis_events/.devcontainer/devcontainer.json
+++ b/redis_events/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     "context": "..",
     "args": {
-      "VARIANT": "3.12-bullseye",
+      "VARIANT": "3.12-bookworm",
       "POETRY_VERSION": "1.8.3"
     }
   },

--- a/redis_events/docker/Dockerfile
+++ b/redis_events/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS base
+FROM python:3.12-slim-bookworm AS base
 WORKDIR /usr/src/app
 
 # Install and configure poetry
@@ -19,7 +19,7 @@ ARG install_flags='--with integration --extras aca-py'
 RUN poetry install ${install_flags}
 USER $user
 
-FROM python:3.12-bullseye
+FROM python:3.12-bookworm
 WORKDIR /usr/src/app
 COPY --from=base /usr/src/app/.venv /usr/src/app/.venv
 ENV PATH="/usr/src/app/.venv/bin:$PATH"

--- a/redis_events/docker/services/Dockerfile
+++ b/redis_events/docker/services/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS base
+FROM python:3.12-slim-bookworm AS base
 WORKDIR /usr/src/app
 
 # Install and configure poetry
@@ -16,7 +16,7 @@ COPY ./docker/services/pyproject.toml ./docker/services/poetry.lock ./
 RUN poetry install
 USER $user
 
-FROM python:3.12-bullseye
+FROM python:3.12-bookworm
 WORKDIR /usr/src/app
 COPY --from=base /usr/src/app/.venv /usr/src/app/.venv
 ENV PATH="/usr/src/app/.venv/bin:$PATH"

--- a/redis_events/integration/Dockerfile
+++ b/redis_events/integration/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS base
+FROM python:3.12-slim-bookworm AS base
 WORKDIR /usr/src/app
 
 # Install and configure poetry
@@ -19,7 +19,7 @@ ARG install_flags='--with integration --extras aca-py'
 RUN poetry install ${install_flags}
 USER $user
 
-FROM python:3.12-bullseye
+FROM python:3.12-bookworm
 WORKDIR /usr/src/app
 COPY --from=base /usr/src/app/.venv /usr/src/app/.venv
 ENV PATH="/usr/src/app/.venv/bin:$PATH"

--- a/redis_events/integration/Dockerfile.test.runner
+++ b/redis_events/integration/Dockerfile.test.runner
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 WORKDIR /usr/src/app
 
 # install poetry

--- a/rpc/.devcontainer/devcontainer.json
+++ b/rpc/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     "context": "..",
     "args": {
-      "VARIANT": "3.12-bullseye",
+      "VARIANT": "3.12-bookworm",
       "POETRY_VERSION": "1.8.3"
     }
   },

--- a/rpc/docker/Dockerfile
+++ b/rpc/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS base
+FROM python:3.12-slim-bookworm AS base
 WORKDIR /usr/src/app
 
 # Install and configure poetry
@@ -19,7 +19,7 @@ ARG install_flags='--with integration --extras aca-py'
 RUN poetry install ${install_flags}
 USER $user
 
-FROM python:3.12-bullseye
+FROM python:3.12-bookworm
 WORKDIR /usr/src/app
 COPY --from=base /usr/src/app/.venv /usr/src/app/.venv
 ENV PATH="/usr/src/app/.venv/bin:$PATH"

--- a/rpc/integration/Dockerfile.test.runner
+++ b/rpc/integration/Dockerfile.test.runner
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 WORKDIR /usr/src/app
 
 # install poetry

--- a/status_list/.devcontainer/devcontainer.json
+++ b/status_list/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     "context": "..",
     "args": {
-      "VARIANT": "3.12-bullseye",
+      "VARIANT": "3.12-bookworm",
       "POETRY_VERSION": "1.8.3"
     }
   },

--- a/status_list/container/Dockerfile
+++ b/status_list/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bullseye AS base
+FROM python:3.12-slim-bookworm AS base
 WORKDIR /usr/src/app
 
 # Install and configure poetry
@@ -19,7 +19,7 @@ ARG install_flags='--with integration --extras aca-py'
 RUN poetry install ${install_flags}
 USER $user
 
-FROM python:3.12-bullseye
+FROM python:3.12-bookworm
 WORKDIR /usr/src/app
 COPY --from=base /usr/src/app/.venv /usr/src/app/.venv
 ENV PATH="/usr/src/app/.venv/bin:$PATH"

--- a/status_list/integration/Dockerfile.test.runner
+++ b/status_list/integration/Dockerfile.test.runner
@@ -1,4 +1,4 @@
-FROM python:3.12-slim-bullseye
+FROM python:3.12-slim-bookworm
 WORKDIR /usr/src/app
 
 # install poetry

--- a/webvh/.devcontainer/devcontainer.json
+++ b/webvh/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "dockerfile": "Dockerfile",
     "context": "..",
     "args": {
-      "VARIANT": "3.12-bullseye",
+      "VARIANT": "3.12-bookworm",
       "POETRY_VERSION": "1.8.3"
     }
   },

--- a/webvh/docker/Dockerfile
+++ b/webvh/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS base
+FROM python:3.12-slim-bookworm AS base
 WORKDIR /usr/src/app
 
 # Install and configure poetry
@@ -19,7 +19,7 @@ ARG install_flags='--with integration --extras aca-py'
 RUN poetry install ${install_flags}
 USER $user
 
-FROM python:3.12-bullseye
+FROM python:3.12-bookworm
 WORKDIR /usr/src/app
 COPY --from=base /usr/src/app/.venv /usr/src/app/.venv
 ENV PATH="/usr/src/app/.venv/bin:$PATH"

--- a/webvh/integration/Dockerfile.server
+++ b/webvh/integration/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.12-bookworm
 
 WORKDIR /fastapi
 

--- a/webvh/integration/Dockerfile.test.runner
+++ b/webvh/integration/Dockerfile.test.runner
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim-bookworm
 WORKDIR /usr/src/app
 
 # install poetry


### PR DESCRIPTION
- Debian Bullseye (11) - Released August 2021
  - Uses GLIBC 2.31
- Debian Bookworm (12) - Released June 2023
  - Uses GLIBC 2.36

- Fixes "GLIBC_2.33 / 2.38 not found" errors in integration tests when upgrading to cryptography v44
- Removes need to pin cryptography or ubuntu runner to older versions
- Ensures consistent base OS across all containers

Changes:
- `docker/Dockerfile`
- `integration/Dockerfile.test.runner`
- `.devcontainer.json`
  - bullseye → bookworm
  - slim → slim-bookworm
  - slim-bullseye → slim-bookworm
