### PR TITLE
:wrench: Configure `asyncio_default_fixture_loop_scope`

### DIFF
--- a/basicmessage_storage/integration/pyproject.toml
+++ b/basicmessage_storage/integration/pyproject.toml
@@ -13,6 +13,7 @@ requests = "^2.32.0"
 [tool.poetry.dev-dependencies]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/basicmessage_storage/pyproject.toml
+++ b/basicmessage_storage/pyproject.toml
@@ -60,6 +60,7 @@ ignore = [
 "**/{demo}/*" = ["F841", "D", "E501"]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 testpaths = "basicmessage_storage"
 addopts = """
     -p no:warnings

--- a/cheqd/integration/pyproject.toml
+++ b/cheqd/integration/pyproject.toml
@@ -16,6 +16,7 @@ typing-extensions = "^4.12.2"
 [tool.poetry.dev-dependencies]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/cheqd/pyproject.toml
+++ b/cheqd/pyproject.toml
@@ -63,6 +63,7 @@ ignore = [
 "**/{demo}/*" = ["F841", "D", "E501"]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 testpaths = "cheqd"
 addopts = """
     -p no:warnings
@@ -72,7 +73,6 @@ addopts = """
 markers = []
 junit_family = "xunit1"
 asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "function"
 
 [tool.coverage.run]
 omit = ["*/tests/*", "docker/*", "integration/*", "*/definition.py"]

--- a/connection_update/integration/pyproject.toml
+++ b/connection_update/integration/pyproject.toml
@@ -13,6 +13,7 @@ requests = "^2.32.0"
 [tool.poetry.dev-dependencies]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/connection_update/pyproject.toml
+++ b/connection_update/pyproject.toml
@@ -59,6 +59,7 @@ ignore = [
 "**/{demo}/*" = ["F841", "D", "E501"]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 testpaths = "connection_update"
 addopts = """
     -p no:warnings

--- a/connections/integration/pyproject.toml
+++ b/connections/integration/pyproject.toml
@@ -13,6 +13,7 @@ requests = "^2.32.0"
 [tool.poetry.dev-dependencies]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/connections/pyproject.toml
+++ b/connections/pyproject.toml
@@ -58,6 +58,7 @@ ignore = [
 "**/{tests}/*" = ["F841", "D", "E501"]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 testpaths = "connections"
 addopts = """
     -p no:warnings

--- a/firebase_push_notifications/integration/pyproject.toml
+++ b/firebase_push_notifications/integration/pyproject.toml
@@ -13,6 +13,7 @@ requests = "^2.32.0"
 [tool.poetry.dev-dependencies]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/firebase_push_notifications/pyproject.toml
+++ b/firebase_push_notifications/pyproject.toml
@@ -63,6 +63,7 @@ ignore = [
 "**/{demo}/*" = ["F841", "D", "E501"]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 testpaths = "firebase_push_notifications"
 addopts = """
     -p no:warnings

--- a/hedera/integration/pyproject.toml
+++ b/hedera/integration/pyproject.toml
@@ -15,6 +15,7 @@ pytest-anything = "^0.1.4"
 [tool.poetry.dev-dependencies]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/hedera/pyproject.toml
+++ b/hedera/pyproject.toml
@@ -60,6 +60,7 @@ ignore = [
 "**/{demo}/*" = ["F841", "D", "E501"]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 testpaths = "hedera"
 addopts = """
     -p no:warnings

--- a/multitenant_provider/integration/pyproject.toml
+++ b/multitenant_provider/integration/pyproject.toml
@@ -16,6 +16,7 @@ python-dateutil = "^2.8.2"
 [tool.poetry.dev-dependencies]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/multitenant_provider/pyproject.toml
+++ b/multitenant_provider/pyproject.toml
@@ -62,6 +62,7 @@ ignore = [
 "**/{demo}/*" = ["F841", "D", "E501"]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 testpaths = "multitenant_provider"
 addopts = """
     -p no:warnings

--- a/oid4vc/integration/pyproject.toml
+++ b/oid4vc/integration/pyproject.toml
@@ -25,7 +25,7 @@ ruff = "^0.5.0"
 [tool.poetry.dev-dependencies]
 
 [tool.pytest.ini_options]
-asyncio_default_fixture_loop_scope = "function"
+asyncio_default_fixture_loop_scope = "session"
 addopts = "-m 'not interop'"
 markers = """
 interop: interop testing

--- a/oid4vc/integration/pyproject.toml
+++ b/oid4vc/integration/pyproject.toml
@@ -25,6 +25,7 @@ ruff = "^0.5.0"
 [tool.poetry.dev-dependencies]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 addopts = "-m 'not interop'"
 markers = """
 interop: interop testing

--- a/oid4vc/pyproject.toml
+++ b/oid4vc/pyproject.toml
@@ -85,6 +85,7 @@ ignore = [
 "**/{demo}/*" = ["F841", "D", "E501"]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 testpaths = "oid4vc"
 addopts = """
     -p no:warnings

--- a/oid4vc/pyproject.toml
+++ b/oid4vc/pyproject.toml
@@ -85,7 +85,7 @@ ignore = [
 "**/{demo}/*" = ["F841", "D", "E501"]
 
 [tool.pytest.ini_options]
-asyncio_default_fixture_loop_scope = "function"
+asyncio_default_fixture_loop_scope = "session"
 testpaths = "oid4vc"
 addopts = """
     -p no:warnings

--- a/plugin_globals/integration/pyproject.toml
+++ b/plugin_globals/integration/pyproject.toml
@@ -13,6 +13,7 @@ requests = "^2.32.0"
 [tool.poetry.dev-dependencies]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/plugin_globals/pyproject.toml
+++ b/plugin_globals/pyproject.toml
@@ -59,6 +59,7 @@ ignore = [
 "**/{demo}/*" = ["F841", "D", "E501"]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 testpaths = "plugin_globals"
 addopts = """
     -p no:warnings

--- a/redis_events/integration/pyproject.toml
+++ b/redis_events/integration/pyproject.toml
@@ -20,6 +20,7 @@ pydantic = "^2.10.6"
 [tool.poetry.dev-dependencies]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/redis_events/pyproject.toml
+++ b/redis_events/pyproject.toml
@@ -67,6 +67,7 @@ ignore = [
 "**/{demo}/*" = ["F841", "D", "E501"]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 testpaths = "redis_events"
 addopts = """
     -p no:warnings

--- a/rpc/integration/pyproject.toml
+++ b/rpc/integration/pyproject.toml
@@ -13,6 +13,7 @@ requests = "^2.32.0"
 [tool.poetry.dev-dependencies]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/rpc/pyproject.toml
+++ b/rpc/pyproject.toml
@@ -59,6 +59,7 @@ ignore = [
 "**/{demo}/*" = ["F841", "D", "E501"]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 testpaths = "rpc"
 addopts = """
     -p no:warnings

--- a/status_list/integration/pyproject.toml
+++ b/status_list/integration/pyproject.toml
@@ -17,6 +17,7 @@ ruff = "^0.5.0"
 [tool.poetry.dev-dependencies]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/status_list/pyproject.toml
+++ b/status_list/pyproject.toml
@@ -68,6 +68,7 @@ ignore = [
 "**/{demo}/*" = ["F841", "D", "E501"]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 testpaths = "status_list"
 addopts = """
     -p no:warnings
@@ -77,7 +78,6 @@ addopts = """
 markers = []
 junit_family = "xunit1"
 asyncio_mode = "auto"
-asyncio_default_fixture_loop_scope = "session"
 
 [tool.coverage.run]
 omit = ["*/tests/*", "docker/*", "integration/*", "*/definition.py"]

--- a/status_list/pyproject.toml
+++ b/status_list/pyproject.toml
@@ -68,7 +68,7 @@ ignore = [
 "**/{demo}/*" = ["F841", "D", "E501"]
 
 [tool.pytest.ini_options]
-asyncio_default_fixture_loop_scope = "function"
+asyncio_default_fixture_loop_scope = "session"
 testpaths = "status_list"
 addopts = """
     -p no:warnings

--- a/webvh/integration/pyproject.toml
+++ b/webvh/integration/pyproject.toml
@@ -14,6 +14,7 @@ acapy-controller = {git = "https://github.com/indicio-tech/acapy-minimal-example
 [tool.poetry.dev-dependencies]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/webvh/pyproject.toml
+++ b/webvh/pyproject.toml
@@ -64,6 +64,7 @@ ignore = [
 "**/{demo}/*" = ["F841", "D", "E501"]
 
 [tool.pytest.ini_options]
+asyncio_default_fixture_loop_scope = "function"
 testpaths = "webvh"
 addopts = """
     -p no:warnings


### PR DESCRIPTION
Resolves deprecation warning:
> The configuration option "asyncio_default_fixture_loop_scope" is unset.

> Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future.