### PR TITLE
Allow cheqd DID-Document update with assertionMethod

### DIFF
--- a/cheqd/cheqd/routes.py
+++ b/cheqd/cheqd/routes.py
@@ -96,6 +96,9 @@ class DIDDocumentSchema(Schema):
     authentication = fields.List(
         fields.Str, required=True, metadata={"description": "Authentication Methods"}
     )
+    assertionMethod = fields.List(
+        fields.Str, required=True, metadata={"description": "Assertion Methods"}
+    )
     service = fields.List(
         fields.Nested(ServiceSchema), required=False, metadata={"description": "Services"}
     )


### PR DESCRIPTION
update schema to allow cheqd DID Document updates to include assertionMethods (such that they can be used for purposes like w3c cred issuance)