### PR TITLE
:loud_sound: Change acapy log levels from debug to info

### DIFF
--- a/basicmessage_storage/integration/docker-compose.yml
+++ b/basicmessage_storage/integration/docker-compose.yml
@@ -11,11 +11,11 @@ services:
       dockerfile: docker/Dockerfile
       args:
         - install_flags=--no-interaction --with integration --extras aca-py
-    command: start --arg-file integration.yml --plugin-config plugins.yml --label bob -e http://bob:3000 --log-level debug
+    command: start --arg-file integration.yml --plugin-config plugins.yml --label bob -e http://bob:3000 --log-level info
 
   alice:
     image: plugin-image
-    command: start --arg-file integration.yml --plugin-config plugins.yml --label alice -e http://alice:3000 --log-level debug
+    command: start --arg-file integration.yml --plugin-config plugins.yml --label alice -e http://alice:3000 --log-level info
 
   tests:
     container_name: juggernaut

--- a/cheqd/docker/default.yml
+++ b/cheqd/docker/default.yml
@@ -4,7 +4,7 @@
 #    ./bin/aca-py start --arg-file ./docker/default.yml
 label: cheqd
 
-log-level: DEBUG
+log-level: info
 auto-provision: true
 
 # Admin

--- a/cheqd/docker/integration.yml
+++ b/cheqd/docker/integration.yml
@@ -1,6 +1,6 @@
 label: cheqd
 
-log-level: DEBUG
+log-level: info
 auto-provision: true
 
 # Admin

--- a/cheqd/integration/docker-compose.yml
+++ b/cheqd/integration/docker-compose.yml
@@ -33,7 +33,7 @@ services:
       --wallet-name agency
       --wallet-key insecure
       --auto-provision
-      --log-level debug
+      --log-level info
       --debug-webhooks
       --no-ledger
       --plugin cheqd

--- a/connection_update/integration/docker-compose.yml
+++ b/connection_update/integration/docker-compose.yml
@@ -11,11 +11,11 @@ services:
       dockerfile: docker/Dockerfile
       args:
         - install_flags=--no-interaction --with integration --extras aca-py
-    command: start --arg-file integration.yml --label bob -e http://bob:3000 --log-level debug
+    command: start --arg-file integration.yml --label bob -e http://bob:3000 --log-level info
 
   alice:
     image: plugin-image
-    command: start --arg-file integration.yml --label alice -e http://alice:3000 --log-level debug
+    command: start --arg-file integration.yml --label alice -e http://alice:3000 --log-level info
 
   tests:
       container_name: juggernaut

--- a/connections/docker/default.yml
+++ b/connections/docker/default.yml
@@ -16,7 +16,7 @@ no-ledger: true
 plugin:
   - connections
 
-log-level: debug
+log-level: info
 
 auto-accept-invites: true
 auto-respond-messages: true

--- a/connections/docker/invitee.yml
+++ b/connections/docker/invitee.yml
@@ -16,7 +16,7 @@ no-ledger: true
 plugin:
   - connections
 
-log-level: debug
+log-level: info
 
 auto-accept-invites: true
 auto-respond-messages: true

--- a/connections/integration/docker-compose.yml
+++ b/connections/integration/docker-compose.yml
@@ -11,11 +11,11 @@ services:
       dockerfile: docker/Dockerfile
       args:
         - install_flags=--no-interaction --with integration --extras aca-py
-    command: start --arg-file integration.yml --label bob -e http://bob:3000 --log-level debug
+    command: start --arg-file integration.yml --label bob -e http://bob:3000 --log-level info
 
   alice:
     image: plugin-image
-    command: start --arg-file integration.yml --label alice -e http://alice:3000 --log-level debug
+    command: start --arg-file integration.yml --label alice -e http://alice:3000 --log-level info
 
   tests:
       container_name: juggernaut

--- a/firebase_push_notifications/integration/docker-compose.yml
+++ b/firebase_push_notifications/integration/docker-compose.yml
@@ -11,11 +11,11 @@ services:
       dockerfile: docker/Dockerfile
       args:
         - install_flags=--no-interaction --with integration --extras aca-py
-    command: start --arg-file integration.yml --label bob -e http://bob:3000 --log-level debug
+    command: start --arg-file integration.yml --label bob -e http://bob:3000 --log-level info
 
   alice:
     image: plugin-image
-    command: start --arg-file integration.yml --label alice -e http://alice:3000 --log-level debug
+    command: start --arg-file integration.yml --label alice -e http://alice:3000 --log-level info
 
   tests:
       container_name: juggernaut

--- a/multitenant_provider/integration/docker-compose.yml
+++ b/multitenant_provider/integration/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       dockerfile: docker/Dockerfile
       args:
         - install_flags=--no-interaction --with integration --extras aca-py
-    command: start --arg-file integration.yml --label admin -e http://admin:3000 --log-level debug
+    command: start --arg-file integration.yml --label admin -e http://admin:3000 --log-level info
 
   tests:
     container_name: juggernaut

--- a/oid4vc/demo/docker-compose.yaml
+++ b/oid4vc/demo/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
         --wallet-name issuer
         --wallet-key insecure
         --auto-provision
-        --log-level debug
+        --log-level info
         --debug-webhooks
         --plugin oid4vc
         --plugin sd_jwt_vc

--- a/oid4vc/integration/docker-compose.interop.yml
+++ b/oid4vc/integration/docker-compose.interop.yml
@@ -50,7 +50,7 @@ services:
         --wallet-name issuer
         --wallet-key insecure
         --auto-provision
-        --log-level debug
+        --log-level info
         --debug-webhooks
         --plugin oid4vc
         --plugin sd_jwt_vc

--- a/oid4vc/integration/docker-compose.yml
+++ b/oid4vc/integration/docker-compose.yml
@@ -30,7 +30,7 @@ services:
         --wallet-name issuer
         --wallet-key insecure
         --auto-provision
-        --log-level debug
+        --log-level info
         --debug-webhooks
         --plugin oid4vc
     healthcheck:

--- a/plugin_globals/integration/docker-compose.yml
+++ b/plugin_globals/integration/docker-compose.yml
@@ -11,11 +11,11 @@ services:
       dockerfile: docker/Dockerfile
       args:
         - install_flags=--no-interaction --with integration --extras aca-py
-    command: start --arg-file integration.yml --label bob -e http://bob:3000 --log-level debug
+    command: start --arg-file integration.yml --label bob -e http://bob:3000 --log-level info
 
   alice:
     image: plugin-image
-    command: start --arg-file integration.yml --label alice -e http://alice:3000 --log-level debug
+    command: start --arg-file integration.yml --label alice -e http://alice:3000 --log-level info
 
   tests:
       container_name: juggernaut

--- a/rpc/integration/docker-compose.yml
+++ b/rpc/integration/docker-compose.yml
@@ -11,11 +11,11 @@ services:
       dockerfile: docker/Dockerfile
       args:
         - install_flags=--no-interaction --with integration --extras aca-py
-    command: start --arg-file integration.yml --label bob -e http://bob:3000 --log-level debug
+    command: start --arg-file integration.yml --label bob -e http://bob:3000 --log-level info
 
   alice:
     image: plugin-image
-    command: start --arg-file integration.yml --label alice -e http://alice:3000 --log-level debug
+    command: start --arg-file integration.yml --label alice -e http://alice:3000 --log-level info
 
   tests:
       container_name: juggernaut

--- a/status_list/integration/docker-compose.yml
+++ b/status_list/integration/docker-compose.yml
@@ -11,11 +11,11 @@ services:
       dockerfile: container/Dockerfile
       args:
         - install_flags=--no-interaction --with integration --all-extras
-    command: start --arg-file integration.yml --label bob -e http://bob:3000 --log-level debug
+    command: start --arg-file integration.yml --label bob -e http://bob:3000 --log-level info
 
   alice:
     image: status-list
-    command: start --arg-file integration.yml --label alice -e http://alice:3000 --log-level debug
+    command: start --arg-file integration.yml --label alice -e http://alice:3000 --log-level info
 
   tests:
     container_name: juggernaut


### PR DESCRIPTION
Reduces spam generated during integration test runs -- dumping logs can be excessively noisy

edit: default warning level might be better, and only reduce level when necessary for bug fixes. But let's just go debug->info for now