### PR TITLE
:art: Update UUID validation (use stricter, canonical UUID format)

### DIFF
--- a/cheqd/cheqd/validation.py
+++ b/cheqd/cheqd/validation.py
@@ -10,7 +10,9 @@ class CheqdDID(Regexp):
 
     EXAMPLE = "did:cheqd:testnet:099be283-4302-40cc-9850-22016bcd1d86"
 
-    UUID = r"([a-z,0-9,-]{36,36})"
+    UUID = (
+        r"([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})"
+    )
     ID_CHAR = r"(?:[a-zA-Z0-9]{21,22}|" + UUID + ")"
     NETWORK = r"(testnet|mainnet)"
     METHOD_ID = r"(?:" + ID_CHAR + r"*:)*(" + ID_CHAR + r"+)"


### PR DESCRIPTION
Improves on the expected UUID format

Wanted to just drop the commas and simplify {36,36} -> {36}, but figured may as well enforce canonical UUID format, and allow upper case hex as well. Happy to remove upper case if necessary