### PR TITLE
[WIP] Self attest with non-auto attestation

### DIFF
--- a/webvh/.devcontainer/post-install.sh
+++ b/webvh/.devcontainer/post-install.sh
@@ -8,4 +8,4 @@ WORKSPACE_DIR=$(pwd)
 python -m pip install --upgrade pip
 
 # Generate Poetry Lock file
-poetry lock --no-update
+poetry lock

--- a/webvh/poetry.lock
+++ b/webvh/poetry.lock
@@ -2975,4 +2975,4 @@ aca-py = ["acapy-agent"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.12"
-content-hash = "67fd41fcfd682f92e98a8a3ebab50652c3ad3e756fbd516c5755c11a80808577"
+content-hash = "d76d0ebdde0d3c6fa55412dde4d5e141191b729cb8945ab06949ab931c135c6f"

--- a/webvh/pyproject.toml
+++ b/webvh/pyproject.toml
@@ -11,7 +11,7 @@ python = "^3.12"
 # explicitly installed with the plugin if desired.
 acapy-agent = { version = "~1.3.0", optional = true }
 
-did-webvh = "^1.0.0rc0"
+did-webvh = "1.0.0rc0"
 jcs = "^0.2.1"
 multiformats = "^0.3.1.post4"
 bitstring = "^4.3.0"

--- a/webvh/webvh/did/constants.py
+++ b/webvh/webvh/did/constants.py
@@ -14,3 +14,5 @@ PROOF_OPTIONS = {
 }
 
 SUPPORTED_KEY_TYPES = ["Multikey", "JsonWebKey"]
+
+WEBVH_METHOD = "did:webvh:1.0"

--- a/webvh/webvh/did/server_client.py
+++ b/webvh/webvh/did/server_client.py
@@ -1,0 +1,86 @@
+"""A client for interacting with the WebVH server API."""
+
+import http
+
+from acapy_agent.core.profile import Profile
+from aiohttp import ClientConnectionError, ClientSession
+
+from ..config.config import get_server_url, use_strict_ssl
+from .exceptions import DidCreationError
+from .utils import all_are_not_none
+
+
+class WebVHServerClient:
+    """A class to handle communication with the WebVH server."""
+
+    def __init__(self, profile: Profile):
+        """Initialize the WebVHServerClient with a profile."""
+        self.profile = profile
+
+    async def request_identifier(self, namespace, identifier) -> tuple:
+        """Contact the trust did web server to request an identifier."""
+        async with ClientSession() as session:
+            try:
+                response = await session.get(
+                    await get_server_url(self.profile),
+                    params={
+                        "namespace": namespace,
+                        "identifier": identifier,
+                    },
+                    ssl=(await use_strict_ssl(self.profile)),
+                )
+            except ClientConnectionError as err:
+                raise DidCreationError(f"Failed to connect to Webvh server: {err}")
+
+            response_json = await response.json()
+            if (
+                response.status == http.HTTPStatus.BAD_REQUEST
+                or response.status == http.HTTPStatus.CONFLICT
+            ):
+                raise DidCreationError(response_json.get("detail"))
+
+            did_document = response_json.get("didDocument", {})
+            did = did_document.get("id")
+
+            proof_options = response_json.get("proofOptions", {})
+            challenge = proof_options.get("challenge")
+            domain = proof_options.get("domain")
+            expiration = proof_options.get("expires")
+
+            if all_are_not_none(did, challenge, domain, expiration):
+                return did_document, proof_options
+            else:
+                raise DidCreationError(
+                    "Invalid response from Webvh server requesting identifier"
+                )
+
+    async def register_did_doc(self, registration_document):
+        """Register a DID document and did with the WebVH server."""
+        async with ClientSession() as session:
+            # Register did document and did with the server
+            response = await session.post(
+                await get_server_url(self.profile),
+                json={"didDocument": registration_document},
+                ssl=(await use_strict_ssl(self.profile)),
+            )
+            response_json = await response.json()
+            if response.status == http.HTTPStatus.BAD_REQUEST:
+                raise DidCreationError(response_json.get("detail"))
+
+    async def submit_initial_log_entry(self, log_entry, namespace, identifier):
+        """Submit an initial log entry to the WebVH server."""
+        async with ClientSession() as session:
+            response = await session.post(
+                f"{await get_server_url(self.profile)}/{namespace}/{identifier}",
+                json={"logEntry": log_entry},
+                ssl=(await use_strict_ssl(self.profile)),
+            )
+
+            if response.status == http.HTTPStatus.INTERNAL_SERVER_ERROR:
+                raise DidCreationError("Server had a problem creating log entry.")
+
+            response_json = await response.json()
+            if response.status == http.HTTPStatus.BAD_REQUEST:
+                raise DidCreationError(response_json.get("detail"))
+
+        return response_json

--- a/webvh/webvh/did/tests/test_witness_manager.py
+++ b/webvh/webvh/did/tests/test_witness_manager.py
@@ -199,6 +199,16 @@ class TestWitnessManager(IsolatedAsyncioTestCase):
             await WitnessManager(self.profile).attest_did_request_doc("test-id")
 
     async def test_attest_did_request_doc(self):
+        self.profile.settings.set_value(
+            "plugin_config",
+            {
+                "did-webvh": {
+                    "role": "controller",
+                    "server_url": "https://id.test-suite.app",
+                }
+            },
+        )
+
         async with self.profile.session() as session:
             await MultikeyManager(session).create(
                 alg="ed25519",
@@ -208,6 +218,7 @@ class TestWitnessManager(IsolatedAsyncioTestCase):
                 PENDING_DOCUMENT_TABLE_NAME,
                 "test-id",
                 value_json=mock_did_doc,
+                tags={"connection_id": "test-conn-id"},
             )
 
         result = await WitnessManager(self.profile).attest_did_request_doc("test-id")

--- a/webvh/webvh/did/utils.py
+++ b/webvh/webvh/did/utils.py
@@ -1,14 +1,13 @@
 """Utilities for shared functions."""
 
 import base64
-import jcs
-import json
 import hashlib
-from multiformats import multibase, multihash
+import json
 
+import jcs
 from aiohttp import ClientResponseError, ClientSession
-
 from did_webvh.core.state import DocumentState
+from multiformats import multibase, multihash
 
 WITNESS_CONNECTION_ALIAS_SUFFIX = "@witness"
 ALIAS_PURPOSES = {
@@ -93,3 +92,8 @@ async def fetch_document_state(url):
     except ClientResponseError:
         pass
     return document_state
+
+
+def all_are_not_none(*args):
+    """Check if all arguments are not None."""
+    return all(v is not None for v in args)

--- a/webvh/webvh/did/witness_manager.py
+++ b/webvh/webvh/did/witness_manager.py
@@ -1,6 +1,7 @@
 """Module to manage witnesses for a DID."""
 
 import asyncio
+import json
 import logging
 from typing import Optional
 
@@ -18,11 +19,12 @@ from acapy_agent.protocols.out_of_band.v1_0.messages.invitation import (
 )
 from acapy_agent.vc.data_integrity.manager import DataIntegrityManager
 from acapy_agent.vc.data_integrity.models.options import DataIntegrityProofOptions
+from acapy_agent.wallet.error import WalletNotFoundError
 from acapy_agent.wallet.keys.manager import MultikeyManager, MultikeyManagerError
 from aries_askar import AskarError
 
 from ..config.config import get_plugin_config, get_server_url, is_controller
-from .exceptions import WitnessError
+from .exceptions import ConfigurationError, WitnessError
 from .messages.witness import WitnessRequest, WitnessResponse
 from .registration_state import RegistrationState
 from .utils import create_alias, server_url_to_domain
@@ -69,7 +71,6 @@ class WitnessManager:
                         kid=key_alias,
                         multikey=key,
                     )
-
                 else:
                     key_info = await manager.create(
                         kid=key_alias,
@@ -77,6 +78,8 @@ class WitnessManager:
                     )
             except MultikeyManagerError:
                 key_info = await manager.from_kid(key_alias)
+            except WalletNotFoundError:
+                raise ConfigurationError("Provided key not found in wallet.")
         return key_info
 
     async def witness_registration_document(
@@ -86,7 +89,8 @@ class WitnessManager:
         parameter_options: dict,
     ) -> Optional[dict]:
         """Witness the document with the given parameters."""
-        role = (await get_plugin_config(self.profile)).get("role")
+        config = await get_plugin_config(self.profile)
+        role = config.get("role")
         async with self.profile.session() as session:
             # Self witness
             if not role or role == "witness":
@@ -103,13 +107,21 @@ class WitnessManager:
                 witness_key_info = await MultikeyManager(session).from_kid(witness_alias)
                 witness_key = witness_key_info.get("multikey")
 
-                return await DataIntegrityManager(session).add_proof(
+                signed_doc = await DataIntegrityManager(session).add_proof(
                     registration_document,
                     DataIntegrityProofOptions.deserialize(
                         proof_options
                         | {"verificationMethod": f"did:key:{witness_key}#{witness_key}"}
                     ),
                 )
+
+                if not config.get("auto_attest", True):
+                    await self.save_did_request_doc_for_witnessing(
+                        signed_doc, connection_id=None, parameters=parameter_options
+                    )
+                    return
+
+                return signed_doc
 
             # Need proof from witness agent
             else:
@@ -183,7 +195,7 @@ class WitnessManager:
         )
 
     async def save_did_request_doc_for_witnessing(
-        self, log_entry: dict, connection_id: str = None
+        self, log_entry: dict, connection_id: Optional[str] = None, parameters: dict = {}
     ):
         """Save an did request doc to the wallet to be witnessed."""
         async with self.profile.session() as session:
@@ -193,11 +205,12 @@ class WitnessManager:
                     log_entry["id"],
                     value_json=log_entry,
                     tags={
-                        "connection_id": connection_id,
+                        "connection_id": connection_id or "",
+                        "parameters": json.dumps(parameters),
                     },
                 )
-            except AskarError:
-                raise WitnessError("log entry already pending a witness.")
+            except AskarError as e:
+                raise WitnessError(f"Error adding pending document: {e}")
 
     async def get_pending_did_request_docs(self) -> list:
         """Get did request docs that are pending a witness."""
@@ -213,6 +226,7 @@ class WitnessManager:
             if entry is None:
                 raise WitnessError("Failed to find pending document.")
 
+            connection_id = entry.tags.get("connection_id")
             document_json = entry.value_json
 
             proof = document_json.get("proof")
@@ -249,15 +263,24 @@ class WitnessManager:
                     challenge=proof.get("challenge"),
                 ),
             )
-            responder = self.profile.inject(BaseResponder)
-            await responder.send(
-                message=WitnessResponse(
-                    state=RegistrationState.ATTESTED.value,
-                    document=witnessed_document,
-                    parameters={},
-                ),
-                connection_id=entry.tags.get("connection_id"),
-            )
+
+            if not connection_id:
+                # Becomes the controller / Avoid circular import
+                from .controller_manager import ControllerManager
+
+                await ControllerManager(self.profile).finish_registration(
+                    entry.value_json, json.loads(entry.tags.get("parameters", {}))
+                )
+            else:
+                responder = self.profile.inject(BaseResponder)
+                await responder.send(
+                    message=WitnessResponse(
+                        state=RegistrationState.ATTESTED.value,
+                        document=witnessed_document,
+                        parameters={},
+                    ),
+                    connection_id=connection_id,
+                )
 
             await session.handle.remove(PENDING_DOCUMENT_TABLE_NAME, entry_id)
 

--- a/webvh/webvh/did/witness_manager.py
+++ b/webvh/webvh/did/witness_manager.py
@@ -269,7 +269,7 @@ class WitnessManager:
                 from .controller_manager import ControllerManager
 
                 await ControllerManager(self.profile).finish_registration(
-                    entry.value_json, json.loads(entry.tags.get("parameters", {}))
+                    entry.value_json, json.loads(entry.tags.get("parameters", "{}"))
                 )
             else:
                 responder = self.profile.inject(BaseResponder)

--- a/webvh/webvh/routes.py
+++ b/webvh/webvh/routes.py
@@ -61,7 +61,9 @@ async def configure(request: web.BaseRequest):
 
     config["scids"] = config.get("scids") or {}
     config["witnesses"] = config.get("witnesses") or []
-    config["server_url"] = request_json.get("server_url") or config.get("server_url")
+    config["server_url"] = (
+        request_json.get("server_url") or config.get("server_url")
+    ).rstrip("/")
 
     if not config.get("server_url"):
         raise ConfigurationError("No server url provided.")


### PR DESCRIPTION
Moved some server request logic to a client service.

Queue self attested log entries when agent is a witness but auto-attest is false.

Thought about trying to avoid the witness using controller module but decided against it as the witness does pretty much become a controller when sending it's initial log entry to the server. Avoided circular imports by importing them only when this happens.


TODO: More automated tests