### PR TITLE
Add watchers notification on DID updates

### DIFF
--- a/webvh/webvh/config/config.py
+++ b/webvh/webvh/config/config.py
@@ -42,6 +42,11 @@ async def is_controller(profile: Profile):
     return (await get_plugin_config(profile)).get("role") == "controller"
 
 
+async def notify_watchers(profile: Profile):
+    """Check if we should notify watchers."""
+    return (await get_plugin_config(profile)).get("notify_watchers", False)
+
+
 async def get_server_url(profile: Profile):
     """Get the server info."""
     server_url = (await get_plugin_config(profile)).get("server_url")

--- a/webvh/webvh/config/webvh_config_record.py
+++ b/webvh/webvh/config/webvh_config_record.py
@@ -33,6 +33,11 @@ class WebvhConfigSchema(BaseRecordSchema):
         description="WebVH Server",
     )
 
+    notify_watchers = fields.Bool(
+        required=True,
+        description="Notify watchers",
+    )
+
     witnesses = fields.List(
         fields.Str(),
         required=False,

--- a/webvh/webvh/did/controller_manager.py
+++ b/webvh/webvh/did/controller_manager.py
@@ -29,6 +29,7 @@ from ..config.config import (
     did_from_scid,
     get_plugin_config,
     get_witnesses,
+    notify_watchers
 )
 from .exceptions import DidCreationError, OperationError
 from .registration_state import RegistrationState
@@ -604,7 +605,7 @@ class ControllerManager:
                 tags={},
             )
 
-        if get_plugin_config(self.profile).get("notify_watchers", False):
+        if notify_watchers(self.profile):
             for watcher in params.get("watchers", []):
                 await WebVHWatcherClient(self.profile).notify_watcher(did, watcher)
 

--- a/webvh/webvh/did/controller_manager.py
+++ b/webvh/webvh/did/controller_manager.py
@@ -29,7 +29,7 @@ from ..config.config import (
     did_from_scid,
     get_plugin_config,
     get_witnesses,
-    notify_watchers
+    notify_watchers,
 )
 from .exceptions import DidCreationError, OperationError
 from .registration_state import RegistrationState
@@ -61,6 +61,7 @@ class ControllerManager:
         """Initialize the DID Webvh Manager."""
         self.profile = profile
         self.server_client = WebVHServerClient(profile)
+        self.watcher_client = WebVHWatcherClient(profile)
 
     async def _get_or_create_key(self, key_alias):
         async with self.profile.session() as session:
@@ -606,8 +607,7 @@ class ControllerManager:
             )
 
         if notify_watchers(self.profile):
-            for watcher in params.get("watchers", []):
-                await WebVHWatcherClient(self.profile).notify_watcher(did, watcher)
+            await self.watcher_client.notify_watchers(did, params.get("watchers", []))
 
         return await response.json()
 
@@ -666,4 +666,3 @@ class ControllerManager:
             identifier,
             vp,
         )
-

--- a/webvh/webvh/did/models/operations.py
+++ b/webvh/webvh/did/models/operations.py
@@ -18,6 +18,14 @@ class ConfigureWebvhSchema(OpenAPISchema):
             "example": "http://localhost:8000",
         },
     )
+    notify_watchers = fields.Boolean(
+        required=False,
+        metadata={
+            "description": "Notify watchers on DID updates",
+            "example": "false",
+        },
+        default=False,
+    )
     witness = fields.Boolean(
         required=False,
         metadata={
@@ -146,6 +154,14 @@ class WebvhCreateSchema(OpenAPISchema):
             metadata={
                 "description": "The witness treshold",
                 "example": 1,
+            },
+        )
+        watchers = fields.List(
+            fields.Str(),
+            required=False,
+            metadata={
+                "description": "List of watchers for this DID.",
+                "example": "https://watcher.webvh.test-suite.app",
             },
         )
         namespace = fields.Str(

--- a/webvh/webvh/did/models/operations.py
+++ b/webvh/webvh/did/models/operations.py
@@ -161,7 +161,7 @@ class WebvhCreateSchema(OpenAPISchema):
             required=False,
             metadata={
                 "description": "List of watchers for this DID.",
-                "example": "https://watcher.webvh.test-suite.app",
+                "example": ["https://watcher.webvh.test-suite.app"],
             },
         )
         namespace = fields.Str(

--- a/webvh/webvh/did/server_client.py
+++ b/webvh/webvh/did/server_client.py
@@ -12,6 +12,20 @@ from .exceptions import DidCreationError, OperationError
 from .utils import all_are_not_none
 
 
+class WebVHWatcherClient:
+    """A class to handle communication with the WebVH watchers."""
+
+    def __init__(self, profile: Profile):
+        """Initialize the WebVHWatcherClient with a profile."""
+        self.profile = profile
+
+    async def notify_watcher(self, did: str, watcher: str):
+        """Notify watchers."""
+
+        async with ClientSession() as http_session:
+            await http_session.post(f"{watcher}/log?did={did}")
+
+
 class WebVHServerClient:
     """A class to handle communication with the WebVH server."""
 

--- a/webvh/webvh/did/server_client.py
+++ b/webvh/webvh/did/server_client.py
@@ -19,11 +19,12 @@ class WebVHWatcherClient:
         """Initialize the WebVHWatcherClient with a profile."""
         self.profile = profile
 
-    async def notify_watcher(self, did: str, watcher: str):
+    async def notify_watchers(self, did: str, watchers: str):
         """Notify watchers."""
 
         async with ClientSession() as http_session:
-            await http_session.post(f"{watcher}/log?did={did}")
+            for watcher in watchers:
+                await http_session.post(f"{watcher}/log?did={did}")
 
 
 class WebVHServerClient:

--- a/webvh/webvh/routes.py
+++ b/webvh/webvh/routes.py
@@ -59,11 +59,12 @@ async def configure(request: web.BaseRequest):
     # Build the config object
     config = await get_plugin_config(profile)
 
-    config["scids"] = config.get("scids") or {}
-    config["witnesses"] = config.get("witnesses") or []
-    config["server_url"] = (
-        request_json.get("server_url") or config.get("server_url")
+    config["scids"] = config.get("scids", {})
+    config["witnesses"] = config.get("witnesses", [])
+    config["server_url"] = request_json.get(
+        "server_url", config.get("server_url")
     ).rstrip("/")
+    config["notify_watchers"] = request_json.get("notify_watchers", False)
 
     if not config.get("server_url"):
         raise ConfigurationError("No server url provided.")


### PR DESCRIPTION
This PR adds a new webvh configuration flag `notify_watchers` as well as a `watchers` parameter on the DID create route.

When the controller updates a DID and the `notify_watchers` flag is set to `true`, it will notify every watcher from the DID's parameters after uploading the latest DID state to the server.