### PR TITLE
:sparkles: Cheqd: Support long resource names

### DIFF
--- a/cheqd/cheqd/anoncreds/registry.py
+++ b/cheqd/cheqd/anoncreds/registry.py
@@ -117,9 +117,9 @@ class DIDCheqdRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
 
     @staticmethod
     def _get_resource_name(name: str) -> str:
-        """Get resource name, hashing if it exceeds 31 characters."""
-        if len(name) > 31:
-            return hashlib.sha256(name.encode()).hexdigest()[:31]
+        """Get resource name, hashing if it exceeds the limit of 64 characters."""
+        if len(name) > 64:
+            return hashlib.sha256(name.encode()).hexdigest()  # Always 64 characters
         return name
 
     async def setup(self, _context: InjectionContext, registrar_url, resolver_url):

--- a/cheqd/cheqd/anoncreds/registry.py
+++ b/cheqd/cheqd/anoncreds/registry.py
@@ -172,7 +172,7 @@ class DIDCheqdRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         """Register a schema on the registry."""
         resource_type = CheqdAnonCredsResourceType.schema.value
 
-        # Get resource name and hash if it exceeds 31 characters
+        # Get resource name and hash if it exceeds 64 characters
         resource_name = self._get_resource_name(schema.name)
         resource_version = schema.version
 
@@ -297,7 +297,7 @@ class DIDCheqdRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         """Register a credential definition on the registry."""
         resource_type = CheqdAnonCredsResourceType.credentialDefinition.value
 
-        # Generate resource name and hash if it exceeds 31 characters
+        # Generate resource name and hash if it exceeds 64 characters
         resource_name = self._get_resource_name(
             f"{schema.schema_value.name}-{credential_definition.tag}"
         )
@@ -384,7 +384,7 @@ class DIDCheqdRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         )
         cred_def_res = cred_def_result.credential_definition_metadata.get("resourceName")
 
-        # Generate resource name and hash if it exceeds 31 characters
+        # Generate resource name and hash if it exceeds 64 characters
         resource_name = self._get_resource_name(
             f"{cred_def_res}-{revocation_registry_definition.tag}"
         )

--- a/cheqd/cheqd/anoncreds/registry.py
+++ b/cheqd/cheqd/anoncreds/registry.py
@@ -1,5 +1,6 @@
 """DID Cheqd AnonCreds Registry."""
 
+import hashlib
 import logging
 import time
 from datetime import datetime, timezone
@@ -114,6 +115,13 @@ class DIDCheqdRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         ids = schema_id.split("/")
         return ids[0], ids[2]
 
+    @staticmethod
+    def _get_resource_name(name: str) -> str:
+        """Get resource name, hashing if it exceeds 31 characters."""
+        if len(name) > 31:
+            return hashlib.sha256(name.encode()).hexdigest()[:31]
+        return name
+
     async def setup(self, _context: InjectionContext, registrar_url, resolver_url):
         """Setup."""
         self.registrar = DIDRegistrar("cheqd", registrar_url)
@@ -163,7 +171,9 @@ class DIDCheqdRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
     ) -> SchemaResult:
         """Register a schema on the registry."""
         resource_type = CheqdAnonCredsResourceType.schema.value
-        resource_name = f"{schema.name}"
+
+        # Get resource name and hash if it exceeds 31 characters
+        resource_name = self._get_resource_name(schema.name)
         resource_version = schema.version
 
         try:
@@ -286,8 +296,11 @@ class DIDCheqdRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
     ) -> CredDefResult:
         """Register a credential definition on the registry."""
         resource_type = CheqdAnonCredsResourceType.credentialDefinition.value
-        # TODO: max chars are 31 for resource, on exceeding this should be hashed
-        resource_name = f"{schema.schema_value.name}-{credential_definition.tag}"
+
+        # Generate resource name and hash if it exceeds 31 characters
+        resource_name = self._get_resource_name(
+            f"{schema.schema_value.name}-{credential_definition.tag}"
+        )
 
         cred_def = ResourceCreateRequestOptions(
             options=Options(
@@ -364,14 +377,17 @@ class DIDCheqdRegistry(BaseAnonCredsResolver, BaseAnonCredsRegistrar):
         _options: Optional[dict] = None,
     ) -> RevRegDefResult:
         """Register a revocation registry definition on the registry."""
+        resource_type = CheqdAnonCredsResourceType.revocationRegistryDefinition.value
 
         cred_def_result = await self.get_credential_definition(
             profile, revocation_registry_definition.cred_def_id
         )
         cred_def_res = cred_def_result.credential_definition_metadata.get("resourceName")
-        # TODO: max chars are 31 for resource name, on exceeding this should be hashed
-        resource_name = f"{cred_def_res}-{revocation_registry_definition.tag}"
-        resource_type = CheqdAnonCredsResourceType.revocationRegistryDefinition.value
+
+        # Generate resource name and hash if it exceeds 31 characters
+        resource_name = self._get_resource_name(
+            f"{cred_def_res}-{revocation_registry_definition.tag}"
+        )
 
         rev_reg_def = ResourceCreateRequestOptions(
             options=Options(

--- a/cheqd/cheqd/anoncreds/tests/test_registry.py
+++ b/cheqd/cheqd/anoncreds/tests/test_registry.py
@@ -664,3 +664,33 @@ async def test_create_not_finished(
     # Assert
     assert isinstance(e.value, AnonCredsRegistrationError)
     assert str(e.value) == "Error publishing Resource Not finished"
+
+
+def test_get_resource_name():
+    """Test _get_resource_name method with different name lengths."""
+    # Short name (under 64 characters)
+    short_name = "test_schema"
+    result = DIDCheqdRegistry._get_resource_name(short_name)
+    assert result == short_name
+
+    # Exactly 64 characters
+    exact_64_name = "a" * 64
+    result = DIDCheqdRegistry._get_resource_name(exact_64_name)
+    assert result == exact_64_name
+    assert len(result) == 64
+
+    # Over 64 characters - should be hashed
+    long_name = "a" * 65
+    result = DIDCheqdRegistry._get_resource_name(long_name)
+    assert result != long_name  # Should be different (hashed)
+    assert len(result) == 64  # SHA-256 hex digest is always 64 chars
+
+    # Very long name - should still result in 64 char hash
+    very_long_name = "test_" * 100  # 500 characters
+    result = DIDCheqdRegistry._get_resource_name(very_long_name)
+    assert result != very_long_name
+    assert len(result) == 64
+
+    # Same long input should produce same hash (deterministic)
+    result2 = DIDCheqdRegistry._get_resource_name(very_long_name)
+    assert result2 == result


### PR DESCRIPTION
Currently the DID Registrar will fail if a resource name is longer than 64 characters. This will now automatically hash resource names longer than that limit.

Signed-off-by: ff137 <ff137@proton.me>