### PR TITLE
🎨 Reduce noisy logs

### DIFF
--- a/cheqd/docker/docker-compose.yml
+++ b/cheqd/docker/docker-compose.yml
@@ -51,6 +51,7 @@ services:
 
       # Interface and port to listen on in the container
       RESOLVER_LISTENER: "0.0.0.0:8080"
+
   tails:
     image: ghcr.io/bcgov/tails-server:latest
     platform: linux/amd64
@@ -61,6 +62,7 @@ services:
       --host 0.0.0.0
       --port 6543
       --storage-path /tmp/tails-files
-      --log-level info
+      --log-level INFO
+
 volumes:
   postgres_data:

--- a/cheqd/integration/docker-compose.yml
+++ b/cheqd/integration/docker-compose.yml
@@ -134,4 +134,4 @@ services:
       --host 0.0.0.0
       --port 6543
       --storage-path /tmp/tails-files
-      --log-level info
+      --log-level INFO

--- a/cheqd/integration/docker-compose.yml
+++ b/cheqd/integration/docker-compose.yml
@@ -91,7 +91,8 @@ services:
     depends_on:
       - driver-did-cheqd
     environment:
-      LOG_LEVEL: "warn"
+      LOGGING_LEVEL_ROOT: "WARN"
+      LOGGING_LEVEL_uniregistrar: "WARN"
 
   driver-did-cheqd:
     image: ghcr.io/cheqd/did-registrar:production-latest

--- a/cheqd/integration/docker-compose.yml
+++ b/cheqd/integration/docker-compose.yml
@@ -90,6 +90,8 @@ services:
       - "9080:9080"
     depends_on:
       - driver-did-cheqd
+    environment:
+      LOG_LEVEL: "warn"
 
   driver-did-cheqd:
     image: ghcr.io/cheqd/did-registrar:production-latest

--- a/hedera/demo/docker-compose.yml
+++ b/hedera/demo/docker-compose.yml
@@ -45,4 +45,4 @@ services:
       --host 0.0.0.0
       --port 6543
       --storage-path /tmp/tails-files
-      --log-level info
+      --log-level INFO

--- a/hedera/integration/docker-compose.yml
+++ b/hedera/integration/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       --host 0.0.0.0
       --port 6543
       --storage-path /tmp/tails-files
-      --log-level info
+      --log-level INFO
 
   tests:
       container_name: juggernaut


### PR DESCRIPTION
Sets the Cheqd did-registrar to LOG_LEVEL: warn, to avoid spamming integration test output

___
PS: A tails-server update was just pushed, which requires --log-level args to be upper case. I notified them that lower case should be supported too. But in the meantime, I'm just changing the tails-server log level to upper case to account for that (as opposed to pinning to previous version)