### PR TITLE
multitenant_provider: fix field name in TokenExpiryConfig

### DIFF
--- a/multitenant_provider/multitenant_provider/v1_0/config.py
+++ b/multitenant_provider/multitenant_provider/v1_0/config.py
@@ -68,7 +68,7 @@ class TokenExpiryConfig(BaseModel):
     @classmethod
     def default(cls):
         """Return default configuration."""
-        return cls(units="weeks", quantity=52)
+        return cls(units="weeks", amount=52)
 
     def get_token_expiry_delta(self) -> timedelta:
         """Return a timedelta representing the token expiry."""


### PR DESCRIPTION
See https://github.com/openwallet-foundation/acapy-plugins/issues/2767, noticed while reviewing other separate PR.

Wouldn't ever run into this in Traction (or anyone ever from what it looks like? Pydantic would ignore unknown field name and default to 52 anyways) the way we call it, but should fix anyways.