### PR TITLE
feat: overlay IssuerConfiguration on .well-known metadata and harden offer parsing

### DIFF
--- a/oid4vc/oid4vc/models/issuer_config.py
+++ b/oid4vc/oid4vc/models/issuer_config.py
@@ -73,25 +73,34 @@ class IssuerConfiguration(BaseRecord):
         return {prop: getattr(self, prop) for prop in self.ISSUER_ATTRS}
 
     def issuer_metadata(self, base_url: str) -> dict:
-        """Return a representation of this record as issuer metadata."""
+        """Return this record as OID4VCI §12.2.4 Credential Issuer metadata.
+
+        Emits every non-null attribute in :data:`ISSUER_ATTRS`. Normalizes
+        `authorization_servers` to public URL strings (§12.2.4 array-of-strings
+        form). Fills the two REQUIRED fields (`credential_issuer`,
+        `credential_endpoint`) from `base_url` when absent; optional fields
+        stay absent unless configured.
+        """
         metadata: dict[str, Any] = {
             prop: getattr(self, prop)
             for prop in self.ISSUER_ATTRS
             if getattr(self, prop) is not None
         }
         if metadata.get("authorization_servers"):
-            metadata["authorization_servers"] = [
-                server.get("public_url", None)
+            # §12.2.4: array of strings, non-empty. Drop entries without public_url.
+            public_urls = [
+                server["public_url"]
                 for server in metadata["authorization_servers"]
+                if server.get("public_url")
             ]
+            if public_urls:
+                metadata["authorization_servers"] = public_urls
+            else:
+                metadata.pop("authorization_servers")
         if not metadata.get("credential_issuer"):
             metadata["credential_issuer"] = base_url
         if not metadata.get("credential_endpoint"):
             metadata["credential_endpoint"] = f"{base_url}/credential"
-        if not metadata.get("nonce_endpoint"):
-            metadata["nonce_endpoint"] = f"{base_url}/nonce"
-        if not metadata.get("notification_endpoint"):
-            metadata["notification_endpoint"] = f"{base_url}/notification"
 
         return metadata
 

--- a/oid4vc/oid4vc/public_routes/metadata.py
+++ b/oid4vc/oid4vc/public_routes/metadata.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from acapy_agent.admin.request_context import AdminRequestContext
 from acapy_agent.messaging.models.openapi import OpenAPISchema
+from acapy_agent.storage.error import StorageNotFoundError
 from acapy_agent.wallet.error import WalletError, WalletNotFoundError
 from acapy_agent.wallet.util import b64_to_bytes
 from aiohttp import web
@@ -17,10 +18,48 @@ from ..config import Config
 from ..cred_processor import CredProcessors
 from ..did_utils import retrieve_or_create_did_jwk
 from ..jwt import jwt_sign
+from ..models.issuer_config import IssuerConfiguration
 from ..models.supported_cred import SupportedCredential
-from ..utils import get_first_auth_server
 
 LOGGER = logging.getLogger(__name__)
+
+
+async def _load_issuer_context(session, wallet_id: str | None):
+    """Load IssuerConfiguration and the first AS entry with a public_url."""
+    try:
+        cfg = await IssuerConfiguration.retrieve_by_id(
+            session, wallet_id or "default-wallet"
+        )
+    except StorageNotFoundError:
+        cfg = None
+    servers = (cfg.authorization_servers if cfg else None) or []
+    auth = next((a for a in servers if a.get("public_url")), None)
+    return cfg, auth
+
+
+def _build_cred_configs(credentials_supported, processors) -> dict:
+    """Build the credential_configurations_supported map."""
+    result: dict = {}
+    for supported in credentials_supported:
+        try:
+            issuer = processors.issuer_for_format(supported.format)
+        except Exception:
+            issuer = None
+        result[supported.identifier] = supported.to_issuer_metadata(issuer=issuer)
+    return result
+
+
+def _apply_overlay(
+    metadata: dict, issuer_config, cred_configs: dict, base_url: str, enable_nonce: bool
+) -> None:
+    """Overlay DB config (keeping server-derived cred_configs) and gate nonce_endpoint."""
+    if issuer_config:
+        metadata.update(issuer_config.issuer_metadata(base_url))
+        metadata["credential_configurations_supported"] = cred_configs
+    if enable_nonce:
+        metadata.setdefault("nonce_endpoint", f"{base_url}/nonce")
+    else:
+        metadata.pop("nonce_endpoint", None)
 
 
 class BatchCredentialIssuanceSchema(OpenAPISchema):
@@ -51,8 +90,10 @@ class CredentialIssuerMetadataSchema(OpenAPISchema):
         required=False,
         metadata={"description": "The nonce endpoint."},
     )
-    credential_configurations_supported = fields.List(
-        fields.Dict(),
+    credential_configurations_supported = fields.Dict(
+        keys=fields.Str(),
+        values=fields.Dict(),
+        required=True,
         metadata={"description": "The supported credentials."},
     )
     batch_credential_issuance = fields.Nested(
@@ -68,8 +109,8 @@ async def credential_issuer_metadata(request: web.Request):
     """Credential issuer metadata endpoint.
 
     If the client sends `Accept: application/jwt`, the metadata is returned as
-    a signed JWT (OID4VCI 1.0 §11.2.2 — signed metadata).  Otherwise, plain
-    JSON is returned.
+    a signed JWT (OID4VCI 1.0 §12.2.2 — metadata retrieval; §12.2.3 defines
+    the signed metadata format). Otherwise, plain JSON is returned.
     """
     context: AdminRequestContext = request["context"]
     config = Config.from_settings(context.settings)
@@ -78,42 +119,34 @@ async def credential_issuer_metadata(request: web.Request):
     async with context.session() as session:
         # TODO If there's a lot, this will be a problem
         credentials_supported = await SupportedCredential.query(session)
-        auth_server = await get_first_auth_server(session, context.profile)
 
         wallet_id = request.match_info.get("wallet_id")
         subpath = f"/tenant/{wallet_id}" if wallet_id else ""
+        issuer_config, auth_server = await _load_issuer_context(session, wallet_id)
+
         metadata: dict[str, Any] = {"credential_issuer": f"{public_url}{subpath}"}
         if auth_server:
-            # Point directly at the auth server's public URL so the wallet
-            # performs OAuth discovery and token requests against the auth server.
             metadata["authorization_servers"] = [auth_server["public_url"]]
         else:
-            # When ACA-Py is its own authorization server (no external auth server),
-            # include token_endpoint directly in the credential issuer metadata.
-            # This is technically an extension beyond OID4VCI spec §11.2.1 (which
-            # says token_endpoint belongs in AS metadata via /.well-known/oauth-
-            # authorization-server), but some wallets (e.g. waltid) read
-            # token_endpoint from resolveCIProviderMetadata() and NPE if absent,
-            # rather than performing AS discovery.
+            # Extension for wallets (e.g. waltid) that read token_endpoint from
+            # credential issuer metadata instead of doing AS discovery.
             metadata["token_endpoint"] = f"{public_url}{subpath}/token"
         metadata["credential_endpoint"] = f"{public_url}{subpath}/credential"
         metadata["notification_endpoint"] = f"{public_url}{subpath}/notification"
-        if config.enable_nonce_endpoint:
-            metadata["nonce_endpoint"] = f"{public_url}{subpath}/nonce"
-        processors = context.inject(CredProcessors)
-        cred_configs = {}
-        for supported in credentials_supported:
-            try:
-                issuer = processors.issuer_for_format(supported.format)
-            except Exception:
-                issuer = None
-            cred_configs[supported.identifier] = supported.to_issuer_metadata(
-                issuer=issuer
-            )
+        cred_configs = _build_cred_configs(
+            credentials_supported, context.inject(CredProcessors)
+        )
         metadata["credential_configurations_supported"] = cred_configs
 
-        # OID4VCI 1.0 §11.2.2: if client requests signed metadata, sign and return
-        # the metadata document as a JWT with Content-Type: application/jwt.
+        _apply_overlay(
+            metadata,
+            issuer_config,
+            cred_configs,
+            f"{public_url}{subpath}",
+            config.enable_nonce_endpoint,
+        )
+
+        # OID4VCI 1.0 §12.2.2/§12.2.3: signed metadata as JWT with application/jwt.
         accept = request.headers.get("Accept", "")
         vm: str | None = None
         jwk_public: dict | None = None
@@ -122,7 +155,6 @@ async def credential_issuer_metadata(request: web.Request):
                 async with context.profile.session() as sig_session:
                     jwk_info = await retrieve_or_create_did_jwk(sig_session)
                 vm = f"{jwk_info.did}#0"
-                # Decode the public JWK from the did:jwk DID.
                 # did:jwk:<base64url(jwk_json)> — reverse _create_default_did.
                 jwk_encoded = jwk_info.did[len("did:jwk:") :]
                 jwk_public = json.loads(b64_to_bytes(jwk_encoded, urlsafe=True).decode())
@@ -130,8 +162,9 @@ async def credential_issuer_metadata(request: web.Request):
                 LOGGER.warning("Cannot sign metadata JWT: %s", err)
 
     if "application/jwt" in accept and vm and jwk_public:
-        # Build JWT payload: include all metadata fields + required JWT claims
-        issuer_url = f"{public_url}{subpath}"
+        # §12.2.3: `sub` MUST match the Credential Issuer Identifier — use the
+        # value in metadata so a DB-overridden credential_issuer is honored.
+        issuer_url = metadata["credential_issuer"]
         payload = {
             **metadata,
             "iss": issuer_url,
@@ -141,13 +174,11 @@ async def credential_issuer_metadata(request: web.Request):
         try:
             signed_jwt = await jwt_sign(
                 context.profile,
-                # Include the public JWK in the header — OID4VCI §11.2.2 / RFC 7515
-                # requires either `jwk` or `x5c` for signed issuer metadata.
-                # The `jwk` must have `kid` matching the JWT header's `kid` so
-                # the conformance suite can locate the correct key.
+                # OID4VCI §12.2.3 requires typ=openidvci-issuer-metadata+jwt.
+                # `jwk` in the header conveys the key (RFC 7515 §4.1.3).
                 headers={
                     "jwk": {**jwk_public, "kid": vm},
-                    "typ": "openid-credential-issuer",
+                    "typ": "openidvci-issuer-metadata+jwt",
                 },
                 payload=payload,
                 verification_method=vm,
@@ -181,60 +212,42 @@ async def openid_configuration(request: web.Request):
     async with context.session() as session:
         # TODO If there's a lot, this will be a problem
         credentials_supported = await SupportedCredential.query(session)
-        auth_server = await get_first_auth_server(session, context.profile)
 
         wallet_id = request.match_info.get("wallet_id")
         subpath = f"/tenant/{wallet_id}" if wallet_id else ""
         base_url = f"{public_url}{subpath}"
+        issuer_config, auth_server = await _load_issuer_context(session, wallet_id)
 
-        processors = context.inject(CredProcessors)
-        cred_configs = {}
-        for supported in credentials_supported:
-            try:
-                issuer = processors.issuer_for_format(supported.format)
-            except Exception:
-                issuer = None
-            cred_configs[supported.identifier] = supported.to_issuer_metadata(
-                issuer=issuer
-            )
+        cred_configs = _build_cred_configs(
+            credentials_supported, context.inject(CredProcessors)
+        )
 
-        # Combined OIDC Discovery + OID4VCI metadata
         metadata: dict[str, Any] = {
-            # OIDC Discovery fields (RFC 8414 / OIDC Discovery required fields)
             "issuer": base_url,
-            # authorization_endpoint is required by CheckServerConfiguration in the
-            # OIDF conformance suite (condition.common.CheckServerConfiguration checks
-            # for "authorization_endpoint", "token_endpoint", and "issuer").
-            # For pre-authorized_code flow the authorization endpoint is not invoked,
-            # but it must be advertised in the AS metadata.
+            # Required by OIDF CheckServerConfiguration; unused in pre-auth flow.
             "authorization_endpoint": f"{base_url}/authorize",
-            "token_endpoint": f"{base_url}/token",
             "response_types_supported": ["code"],
-            # DPoP support - required by HAIP profile (DPOP-5.1).
-            # Advertise the algorithms supported for DPoP proof JWTs.
             "dpop_signing_alg_values_supported": ["ES256", "ES384", "ES512"],
-            # OAuth 2.0 AS Metadata fields
             "grant_types_supported": [
                 "urn:ietf:params:oauth:grant-type:pre-authorized_code"
             ],
-            # RFC 9396 Rich Authorization Requests — advertise the authorization_details
-            # type(s) supported (required by OID4VCI HAIP AS metadata validation).
             "authorization_details_types_supported": ["openid_credential"],
-            # OID4VCI fields
             "credential_issuer": base_url,
             "credential_endpoint": f"{base_url}/credential",
             "notification_endpoint": f"{base_url}/notification",
             "credential_configurations_supported": cred_configs,
         }
 
-        if config.enable_nonce_endpoint:
-            # OID4VCI nonce endpoint for server-generated nonces (HAIP required).
-            # Wallets call this before building a credential proof to get a fresh
-            # nonce that ACA-Py validates in the JWT proof `nonce` claim.
-            metadata["nonce_endpoint"] = f"{base_url}/nonce"
+        # token_endpoint belongs to the AS; only advertise when ACA-Py is its own AS.
+        if not auth_server:
+            metadata["token_endpoint"] = f"{base_url}/token"
 
         if auth_server:
             metadata["authorization_servers"] = [auth_server["public_url"]]
+
+        _apply_overlay(
+            metadata, issuer_config, cred_configs, base_url, config.enable_nonce_endpoint
+        )
 
     LOGGER.debug("OPENID CONFIG: %s", metadata)
 

--- a/oid4vc/oid4vc/routes/helpers.py
+++ b/oid4vc/oid4vc/routes/helpers.py
@@ -80,17 +80,22 @@ async def _parse_cred_offer(context: AdminRequestContext, exchange_id: str) -> d
             supported = await SupportedCredential.retrieve_by_id(
                 session, record.supported_cred_id
             )
-            auth_server = await get_first_auth_server(session, context.profile)
-            record.code = await _create_pre_auth_code(
-                context.profile,
-                config,
-                auth_server,
-                record.refresh_id,
-                supported.identifier,
-                record.pin,
-            )
-            record.state = OID4VCIExchangeRecord.STATE_OFFER_CREATED
-            await record.save(session, reason="Credential offer created")
+            if record.state == OID4VCIExchangeRecord.STATE_CREATED:
+                auth_server = await get_first_auth_server(session, context.profile)
+                record.code = await _create_pre_auth_code(
+                    context.profile,
+                    config,
+                    auth_server,
+                    record.refresh_id,
+                    supported.identifier,
+                    record.pin,
+                )
+                record.state = OID4VCIExchangeRecord.STATE_OFFER_CREATED
+                await record.save(session, reason="Credential offer created")
+            elif record.state != OID4VCIExchangeRecord.STATE_OFFER_CREATED:
+                raise web.HTTPBadRequest(
+                    reason="This exchange record has already been used."
+                )
     except (StorageError, BaseModelError) as err:
         raise web.HTTPBadRequest(reason=err.roll_up) from err
 

--- a/oid4vc/oid4vc/tests/routes/test_public_routes.py
+++ b/oid4vc/oid4vc/tests/routes/test_public_routes.py
@@ -81,6 +81,228 @@ async def test_issuer_metadata(context: AdminRequestContext, req: web.Request):
 
 
 @pytest.mark.asyncio
+async def test_metadata_overlays_issuer_configuration(
+    context: AdminRequestContext, req: web.Request
+):
+    """IssuerConfiguration values override default generated metadata fields.
+
+    Also verifies that when an external authorization server is configured, no
+    `token_endpoint` is advertised in either metadata document.
+    """
+
+    wallet_id = req.match_info.get("wallet_id")
+    display = [
+        {
+            "name": "University Credential",
+            "locale": "en-US",
+            "logo": {
+                "uri": "https://exampleuniversity.com/public/logo.png",
+                "alt_text": "a square logo of a university",
+            },
+        }
+    ]
+    request_encryption = {
+        "keys": [
+            {
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "f83OJ3D2xF4Jqk8rVqYf5UEoR2L7iB42t1R6kzjzA6o",
+                "y": "x_FEzRu9yQ1rZtQxCkVwYg1oHc3mG5m0kYqf9u0Qf6A",
+                "use": "enc",
+                "alg": "ECDH-ES",
+                "kid": "ec-p256-enc-1",
+            }
+        ]
+    }
+    response_encryption = {
+        "alg_values_supported": ["ECDH-ES", "ECDH-ES+A256KW"],
+        "enc_values_supported": ["A256GCM", "A128GCM"],
+        "encryption_required": True,
+        "zip_values_supported": ["DEF"],
+    }
+    async with context.session() as session:
+        issuer_config = IssuerConfiguration(
+            configuration_id=wallet_id,
+            new_with_id=True,
+            credential_issuer="https://issuer.example.com",
+            authorization_servers=[
+                {
+                    "public_url": "https://auth.example.com",
+                    "private_url": "https://auth.internal",
+                    "auth_type": "client_secret_basic",
+                    "client_credentials": {"client_id": "abc", "client_secret": "xyz"},
+                }
+            ],
+            credential_endpoint="https://issuer.example.com/custom-credential",
+            nonce_endpoint="https://issuer.example.com/custom-nonce",
+            deferred_credential_endpoint="https://issuer.example.com/deferred",
+            notification_endpoint="https://issuer.example.com/notify",
+            credential_request_encryption=request_encryption,
+            credential_response_encryption=response_encryption,
+            batch_credential_issuance={"batch_size": 100},
+            display=display,
+        )
+        await issuer_config.save(session)
+
+        supported = SupportedCredential(
+            format="jwt_vc_json",
+            identifier="StoredConfigCredential",
+            credential_metadata={"claims": [{"path": ["name"]}]},
+        )
+        await supported.save(session)
+
+    for endpoint in (
+        test_module.credential_issuer_metadata,
+        test_module.openid_configuration,
+    ):
+        with patch.object(_metadata_module, "web", autospec=True) as mock_web:
+            await endpoint(req)
+        metadata = mock_web.json_response.call_args.args[0]
+
+        # DB overrides the mandatory fields
+        assert metadata["credential_issuer"] == "https://issuer.example.com"
+        assert (
+            metadata["credential_endpoint"]
+            == "https://issuer.example.com/custom-credential"
+        )
+        # authorization_servers normalized to public URLs (§12.2.4)
+        assert metadata["authorization_servers"] == ["https://auth.example.com"]
+        # All configured optional fields flow through the overlay
+        assert metadata["nonce_endpoint"] == "https://issuer.example.com/custom-nonce"
+        assert (
+            metadata["deferred_credential_endpoint"]
+            == "https://issuer.example.com/deferred"
+        )
+        assert metadata["notification_endpoint"] == "https://issuer.example.com/notify"
+        assert metadata["credential_request_encryption"] == request_encryption
+        assert metadata["credential_response_encryption"] == response_encryption
+        assert metadata["batch_credential_issuance"] == {"batch_size": 100}
+        assert metadata["display"] == display
+        # server-derived credentials are not clobbered by the overlay
+        assert "StoredConfigCredential" in metadata["credential_configurations_supported"]
+        # external AS present -> no token_endpoint at the credential issuer
+        assert "token_endpoint" not in metadata
+
+
+@pytest.mark.asyncio
+async def test_authorization_servers_drops_entries_without_public_url(
+    context: AdminRequestContext, req: web.Request
+):
+    """§12.2.4: authorization_servers is an array of strings, non-empty.
+
+    Filter out DB entries missing `public_url` so we never publish `null`.
+    """
+    wallet_id = req.match_info.get("wallet_id")
+    async with context.session() as session:
+        issuer_config = IssuerConfiguration(
+            configuration_id=wallet_id,
+            new_with_id=True,
+            authorization_servers=[
+                {"private_url": "https://intra.example.com"},  # no public_url
+                {"public_url": "https://auth.example.com"},
+            ],
+        )
+        await issuer_config.save(session)
+
+    with patch.object(_metadata_module, "web", autospec=True) as mock_web:
+        await test_module.credential_issuer_metadata(req)
+    metadata = mock_web.json_response.call_args.args[0]
+    assert metadata["authorization_servers"] == ["https://auth.example.com"]
+    assert None not in metadata["authorization_servers"]
+
+
+@pytest.mark.asyncio
+async def test_signed_metadata_uses_spec_typ_header(
+    monkeypatch, context: AdminRequestContext, req: web.Request
+):
+    """§12.2.3: signed metadata JWT MUST use typ=openidvci-issuer-metadata+jwt.
+
+    Also verifies `sub` matches the (possibly DB-overridden) credential_issuer.
+    """
+    from types import SimpleNamespace
+
+    req.headers = {"Accept": "application/jwt"}
+
+    wallet_id = req.match_info.get("wallet_id")
+    async with context.session() as session:
+        await IssuerConfiguration(
+            configuration_id=wallet_id,
+            new_with_id=True,
+            credential_issuer="https://issuer.example.com",
+        ).save(session)
+
+    monkeypatch.setattr(
+        _metadata_module,
+        "retrieve_or_create_did_jwk",
+        AsyncMock(
+            return_value=SimpleNamespace(
+                # did:jwk:<base64url({"kty":"OKP","crv":"Ed25519","x":"AA"})>
+                did="did:jwk:eyJrdHkiOiJPS1AiLCJjcnYiOiJFZDI1NTE5IiwieCI6IkFBIn0"
+            )
+        ),
+    )
+    captured = {}
+
+    async def fake_sign(profile, headers, payload, verification_method):
+        captured["headers"] = headers
+        captured["payload"] = payload
+        return "signed.jwt.value"
+
+    monkeypatch.setattr(_metadata_module, "jwt_sign", fake_sign)
+
+    with patch.object(_metadata_module, "web", autospec=True) as mock_web:
+        mock_web.Response.return_value = MagicMock()
+        await test_module.credential_issuer_metadata(req)
+
+    assert captured["headers"]["typ"] == "openidvci-issuer-metadata+jwt"
+    # §12.2.3: sub REQUIRED = Credential Issuer Identifier; iat REQUIRED.
+    assert captured["payload"]["sub"] == "https://issuer.example.com"
+    assert captured["payload"]["sub"] == captured["payload"]["credential_issuer"]
+    assert isinstance(captured["payload"]["iat"], int)
+
+
+@pytest.mark.asyncio
+async def test_metadata_suppresses_nonce_endpoint_when_disabled(
+    monkeypatch, context: AdminRequestContext, req: web.Request
+):
+    """DB-configured `nonce_endpoint` is suppressed when local nonce is off.
+
+    PoP validation uses direct c_nonce comparison when `enable_nonce_endpoint`
+    is False, so publishing a nonce endpoint would advertise a flow the server
+    cannot validate. The overlay is preserved for every other DB field.
+    """
+    wallet_id = req.match_info.get("wallet_id")
+    async with context.session() as session:
+        issuer_config = IssuerConfiguration(
+            configuration_id=wallet_id,
+            new_with_id=True,
+            nonce_endpoint="https://issuer.example.com/custom-nonce",
+            display=[{"name": "Example Issuer", "locale": "en"}],
+        )
+        await issuer_config.save(session)
+
+    monkeypatch.setattr(
+        _metadata_module.Config,
+        "from_settings",
+        lambda settings: MagicMock(
+            endpoint="http://localhost:8020",
+            enable_nonce_endpoint=False,
+        ),
+    )
+
+    for endpoint in (
+        test_module.credential_issuer_metadata,
+        test_module.openid_configuration,
+    ):
+        with patch.object(_metadata_module, "web", autospec=True) as mock_web:
+            await endpoint(req)
+        metadata = mock_web.json_response.call_args.args[0]
+        assert "nonce_endpoint" not in metadata
+        # Other DB overlay fields still flow through
+        assert metadata["display"] == [{"name": "Example Issuer", "locale": "en"}]
+
+
+@pytest.mark.asyncio
 async def test_get_token(context: AdminRequestContext, req: web.Request):
     """Test token issuance endpoint."""
 

--- a/oid4vc/oid4vc/tests/test_routes.py
+++ b/oid4vc/oid4vc/tests/test_routes.py
@@ -85,7 +85,7 @@ async def test_parse_cred_offer(monkeypatch, context):
     mock_record.pin = "1234"
     mock_record.refresh_id = "refresh_id"
     mock_record.code = None
-    mock_record.state = None
+    mock_record.state = OID4VCIExchangeRecord.STATE_CREATED
     mock_record.save = AsyncMock()
     monkeypatch.setattr(
         "oid4vc.routes.helpers.OID4VCIExchangeRecord.retrieve_by_id",
@@ -100,6 +100,9 @@ async def test_parse_cred_offer(monkeypatch, context):
     )
     monkeypatch.setattr(
         "oid4vc.routes.helpers._create_pre_auth_code", AsyncMock(return_value="code123")
+    )
+    monkeypatch.setattr(
+        "oid4vc.routes.helpers.get_first_auth_server", AsyncMock(return_value=None)
     )
     offer = await _parse_cred_offer(context, "exchange_id")
     assert offer["credential_issuer"].startswith("http://localhost:8020")


### PR DESCRIPTION
- apply IssuerConfiguration overlay to issuer and OIDC metadata endpoints
- keep server-derived credential configurations while honoring DB overrides
- normalize authorization_servers to public URLs and gate nonce endpoint by config
- align signed metadata JWT typ/sub behavior with OID4VCI expectations
- make credential offer code generation idempotent and reject reused exchanges