### PR TITLE
Upload integration test compose logs as artifacts

### DIFF
--- a/.github/workflows/pr-integration-tests.yaml
+++ b/.github/workflows/pr-integration-tests.yaml
@@ -88,6 +88,21 @@ jobs:
         id: integration-tests
         shell: bash
         run: |
+          # Persist compose logs before `down`/`prune` so they can be uploaded
+          # as a job artifact. Per-service files make agent logs (e.g. bob)
+          # easy to download without scraping the Actions log.
+          save_integration_logs() {
+            local plugin="$1"
+            local dest="${GITHUB_WORKSPACE}/integration-logs/${plugin}"
+            mkdir -p "$dest"
+            docker compose logs --no-color > "$dest/compose.log" 2>/dev/null || true
+            local svc
+            for svc in $(docker compose config --services 2>/dev/null); do
+              docker compose logs --no-color "$svc" > "$dest/${svc}.log" 2>/dev/null || true
+            done
+            echo "📦 Saved docker compose logs under integration-logs/${plugin}/"
+          }
+
           for dir in ${{ steps.changed-plugins.outputs.changed-plugins }}; do
 
             if [[ "$dir" == "cheqd" ]]; then
@@ -113,12 +128,19 @@ jobs:
               docker compose up -d
 
               echo "🧪 Running tests container..."
-              docker compose run --rm tests
-              TEST_EXIT=$?
+              # `if` guards the command from bash's `set -e` (used by GitHub
+              # Actions' `shell: bash`), which would otherwise abort the
+              # whole step before logs can be saved.
+              if docker compose run --rm tests; then
+                TEST_EXIT=0
+              else
+                TEST_EXIT=$?
+              fi
 
               if [[ $TEST_EXIT -ne 0 ]]; then
                 echo "❌ Tests failed for $dir - dumping logs:"
-                docker compose logs || true
+                docker compose logs --no-color || true
+                save_integration_logs "$dir"
                 docker compose down --remove-orphans
                 docker system prune -af --volumes
                 exit $TEST_EXIT
@@ -127,7 +149,8 @@ jobs:
               # Normal plugin flow
               if ! docker compose up --exit-code-from tests; then
                 echo "❌ Tests failed for $dir - dumping logs:"
-                docker compose logs
+                docker compose logs --no-color || true
+                save_integration_logs "$dir"
                 docker compose down --remove-orphans
                 docker system prune -af --volumes
                 exit 1
@@ -139,3 +162,11 @@ jobs:
             docker system prune -af --volumes
             cd ../..
           done
+      - name: Upload integration logs
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-logs
+          path: integration-logs/
+          if-no-files-found: ignore
+          retention-days: 14


### PR DESCRIPTION
## Summary
- On integration-test failure, save `docker compose logs` (full stack plus per-service files such as `bob.log`) **before** `compose down` / prune.
- Upload them as the `integration-logs` Actions artifact so agent traces are downloadable instead of only sitting in the truncated job log.
- Guard `cache_redis`'s `docker compose run` with `if` so `set -e` cannot skip log capture.

## Test plan
- [ ] Confirm Integration Tests and unit-test workflows run on this PR
- [ ] If a plugin fails, confirm the job has an `integration-logs` artifact with `<plugin>/bob.log` (or that plugin's agent service names)
- [ ] Confirm a fully green run does not fail the upload step (`if-no-files-found: ignore`)


Made with [Cursor](https://cursor.com)