### PR TITLE
fix(webvh): timeout-safe attested resource publish

### DIFF
--- a/webvh/integration/caddy/Caddyfile
+++ b/webvh/integration/caddy/Caddyfile
@@ -1,0 +1,8 @@
+{
+	auto_https disable_redirects
+}
+
+webvh:443 {
+	tls /certs/webvh.crt /certs/webvh.key
+	reverse_proxy webvh-server:8000
+}

--- a/webvh/integration/caddy/Caddyfile
+++ b/webvh/integration/caddy/Caddyfile
@@ -2,7 +2,7 @@
 	auto_https disable_redirects
 }
 
-webvh:443 {
+webvh.test:443 {
 	tls /certs/webvh.crt /certs/webvh.key
 	reverse_proxy webvh-server:8000
 }

--- a/webvh/integration/certs/entrypoint.sh
+++ b/webvh/integration/certs/entrypoint.sh
@@ -4,8 +4,8 @@ apk add --no-cache openssl ca-certificates >/dev/null
 openssl req -x509 -newkey rsa:2048 -sha256 -days 2 -nodes \
   -keyout /certs/webvh.key \
   -out /certs/webvh.crt \
-  -subj "/CN=webvh" \
-  -addext "subjectAltName=DNS:webvh"
+  -subj "/CN=webvh.test" \
+  -addext "subjectAltName=DNS:webvh.test"
 chmod 644 /certs/webvh.crt /certs/webvh.key
 cat /etc/ssl/certs/ca-certificates.crt /certs/webvh.crt > /certs/ca-bundle.pem
 chmod 644 /certs/ca-bundle.pem

--- a/webvh/integration/certs/entrypoint.sh
+++ b/webvh/integration/certs/entrypoint.sh
@@ -9,3 +9,5 @@ openssl req -x509 -newkey rsa:2048 -sha256 -days 2 -nodes \
 chmod 644 /certs/webvh.crt /certs/webvh.key
 cat /etc/ssl/certs/ca-certificates.crt /certs/webvh.crt > /certs/ca-bundle.pem
 chmod 644 /certs/ca-bundle.pem
+# Stay up: compose --exit-code-from tests aborts if any service exits.
+exec tail -f /dev/null

--- a/webvh/integration/certs/entrypoint.sh
+++ b/webvh/integration/certs/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+apk add --no-cache openssl ca-certificates >/dev/null
+openssl req -x509 -newkey rsa:2048 -sha256 -days 2 -nodes \
+  -keyout /certs/webvh.key \
+  -out /certs/webvh.crt \
+  -subj "/CN=webvh" \
+  -addext "subjectAltName=DNS:webvh"
+chmod 644 /certs/webvh.crt /certs/webvh.key
+cat /etc/ssl/certs/ca-certificates.crt /certs/webvh.crt > /certs/ca-bundle.pem
+chmod 644 /certs/ca-bundle.pem

--- a/webvh/integration/docker-compose.yml
+++ b/webvh/integration/docker-compose.yml
@@ -1,11 +1,84 @@
+# Local WebVH server (not sandbox.bcvh.vonx.io).
+# did:webvh resolution is HTTPS-only, so Caddy terminates TLS for hostname "webvh".
+# Agents trust the test CA via SSL_CERT_FILE (bundle includes public CAs for tails).
+
+x-plugin-agent: &plugin-agent
+  image: plugin-image
+  build:
+    context: ..
+    dockerfile: docker/Dockerfile
+    args:
+      - install_flags=--no-interaction --with integration --extras aca-py
+  environment:
+    SSL_CERT_FILE: /certs/ca-bundle.pem
+    REQUESTS_CA_BUNDLE: /certs/ca-bundle.pem
+    CURL_CA_BUNDLE: /certs/ca-bundle.pem
+  volumes:
+    - webvh-certs:/certs:ro
+  depends_on:
+    webvh-certs:
+      condition: service_completed_successfully
+    webvh-server:
+      condition: service_healthy
+    webvh:
+      condition: service_healthy
+
 services:
+  webvh-certs:
+    image: alpine:3.21
+    volumes:
+      - webvh-certs:/certs
+      - ./certs/entrypoint.sh:/entrypoint.sh:ro
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+
+  webvh-server:
+    image: ghcr.io/decentralized-identity/didwebvh-server-py:0.5.0
+    environment:
+      WEBVH_DOMAIN: webvh
+      APP_PORT: "8000"
+      APP_WORKERS: "1"
+      WEBVH_WITNESS: "false"
+      WEBVH_PREROTATION: "false"
+      WEBVH_PORTABILITY: "false"
+      WEBVH_ENDORSEMENT: "false"
+      ENABLE_TAILS: "false"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python3 -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/api/server/status')\"",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    depends_on:
+      webvh-certs:
+        condition: service_completed_successfully
+
+  webvh:
+    image: caddy:2-alpine
+    volumes:
+      - webvh-certs:/certs:ro
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -qO- http://webvh-server:8000/api/server/status | grep -q ok",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 5s
+    depends_on:
+      webvh-certs:
+        condition: service_completed_successfully
+      webvh-server:
+        condition: service_healthy
+
   witness:
-    image: plugin-image
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile
-      args:
-        - install_flags=--no-interaction --with integration --extras aca-py
+    <<: *plugin-agent
     command: >
       start
         --label Witness
@@ -23,7 +96,8 @@ services:
         --notify-revocation
         --plugin webvh
         --plugin-config-value webvh.witness=true
-        --plugin-config-value webvh.server_url=https://sandbox.bcvh.vonx.io
+        --plugin-config-value webvh.server_url=https://webvh
+        --plugin-config-value webvh.strict_ssl=true
         --tails-server-base-url https://tails.anoncreds.vc
         --auto-provision
         --seed 00000000000000000000000000000000
@@ -32,12 +106,7 @@ services:
         --auto-respond-messages
 
   controller:
-    image: plugin-image
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile
-      args:
-        - install_flags=--no-interaction --with integration --extras aca-py
+    <<: *plugin-agent
     command: >
       start
         --label Controller
@@ -55,17 +124,13 @@ services:
         --monitor-revocation-notification
         --plugin webvh
         --plugin-config-value webvh.witness=false
-        --plugin-config-value webvh.server_url=https://sandbox.bcvh.vonx.io
+        --plugin-config-value webvh.server_url=https://webvh
+        --plugin-config-value webvh.strict_ssl=true
         --auto-accept-invites
         --auto-respond-messages
 
   no_witness:
-    image: plugin-image
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile
-      args:
-        - install_flags=--no-interaction --with integration --extras aca-py
+    <<: *plugin-agent
     command: >
       start
         --label NoWitness
@@ -83,24 +148,41 @@ services:
         --notify-revocation
         --plugin webvh
         --plugin-config-value webvh.witness=false
-        --plugin-config-value webvh.server_url=https://sandbox.bcvh.vonx.io
+        --plugin-config-value webvh.server_url=https://webvh
+        --plugin-config-value webvh.strict_ssl=true
         --plugin-config-value webvh.endorsement=false
         --tails-server-base-url https://tails.anoncreds.vc
         --auto-accept-invites
         --auto-respond-messages
 
   tests:
-      container_name: juggernaut
-      build:
-        context: .
-        dockerfile: Dockerfile.test.runner
-      environment:
-        - WAIT_BEFORE=3
-        - WAIT_HOSTS=witness:3000, controller:3000, no_witness:3000
-        - WAIT_TIMEOUT=60
-        - WAIT_SLEEP_INTERVAL=1
-        - WAIT_HOST_CONNECT_TIMEOUT=30
-      depends_on:
-        - witness
-        - controller
-        - no_witness
+    container_name: juggernaut
+    build:
+      context: .
+      dockerfile: Dockerfile.test.runner
+    environment:
+      - WAIT_BEFORE=3
+      - WAIT_HOSTS=webvh:443, witness:3000, controller:3000, no_witness:3000
+      - WAIT_TIMEOUT=90
+      - WAIT_SLEEP_INTERVAL=1
+      - WAIT_HOST_CONNECT_TIMEOUT=30
+      - WEBVH_DOMAIN=webvh
+      - WEBVH_SERVER_URL=https://webvh
+      - SSL_CERT_FILE=/certs/ca-bundle.pem
+      - REQUESTS_CA_BUNDLE=/certs/ca-bundle.pem
+    volumes:
+      - webvh-certs:/certs:ro
+    depends_on:
+      webvh-certs:
+        condition: service_completed_successfully
+      webvh:
+        condition: service_healthy
+      witness:
+        condition: service_started
+      controller:
+        condition: service_started
+      no_witness:
+        condition: service_started
+
+volumes:
+  webvh-certs:

--- a/webvh/integration/docker-compose.yml
+++ b/webvh/integration/docker-compose.yml
@@ -17,7 +17,7 @@ x-plugin-agent: &plugin-agent
     - webvh-certs:/certs:ro
   depends_on:
     webvh-certs:
-      condition: service_completed_successfully
+      condition: service_healthy
     webvh-server:
       condition: service_healthy
     webvh:
@@ -30,6 +30,12 @@ services:
       - webvh-certs:/certs
       - ./certs/entrypoint.sh:/entrypoint.sh:ro
     entrypoint: ["/bin/sh", "/entrypoint.sh"]
+    healthcheck:
+      test: ["CMD", "test", "-f", "/certs/ca-bundle.pem"]
+      interval: 2s
+      timeout: 2s
+      retries: 20
+      start_period: 5s
 
   webvh-server:
     image: ghcr.io/decentralized-identity/didwebvh-server-py:0.5.0
@@ -54,7 +60,7 @@ services:
       start_period: 20s
     depends_on:
       webvh-certs:
-        condition: service_completed_successfully
+        condition: service_healthy
 
   webvh:
     image: caddy:2-alpine
@@ -73,7 +79,7 @@ services:
       start_period: 5s
     depends_on:
       webvh-certs:
-        condition: service_completed_successfully
+        condition: service_healthy
       webvh-server:
         condition: service_healthy
 
@@ -174,7 +180,7 @@ services:
       - webvh-certs:/certs:ro
     depends_on:
       webvh-certs:
-        condition: service_completed_successfully
+        condition: service_healthy
       webvh:
         condition: service_healthy
       witness:

--- a/webvh/integration/docker-compose.yml
+++ b/webvh/integration/docker-compose.yml
@@ -1,5 +1,6 @@
 # Local WebVH server (not sandbox.bcvh.vonx.io).
-# did:webvh resolution is HTTPS-only, so Caddy terminates TLS for hostname "webvh".
+# did:webvh resolution is HTTPS-only, so Caddy terminates TLS.
+# Hostname must be two DNS labels (did_webvh DomainPath.validate); "webvh" is rejected.
 # Agents trust the test CA via SSL_CERT_FILE (bundle includes public CAs for tails).
 
 x-plugin-agent: &plugin-agent
@@ -40,7 +41,7 @@ services:
   webvh-server:
     image: ghcr.io/decentralized-identity/didwebvh-server-py:0.5.0
     environment:
-      WEBVH_DOMAIN: webvh
+      WEBVH_DOMAIN: webvh.test
       APP_PORT: "8000"
       APP_WORKERS: "1"
       WEBVH_WITNESS: "false"
@@ -64,6 +65,11 @@ services:
 
   webvh:
     image: caddy:2-alpine
+    hostname: webvh.test
+    networks:
+      default:
+        aliases:
+          - webvh.test
     volumes:
       - webvh-certs:/certs:ro
       - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
@@ -102,7 +108,7 @@ services:
         --notify-revocation
         --plugin webvh
         --plugin-config-value webvh.witness=true
-        --plugin-config-value webvh.server_url=https://webvh
+        --plugin-config-value webvh.server_url=https://webvh.test
         --plugin-config-value webvh.strict_ssl=true
         --tails-server-base-url https://tails.anoncreds.vc
         --auto-provision
@@ -130,7 +136,7 @@ services:
         --monitor-revocation-notification
         --plugin webvh
         --plugin-config-value webvh.witness=false
-        --plugin-config-value webvh.server_url=https://webvh
+        --plugin-config-value webvh.server_url=https://webvh.test
         --plugin-config-value webvh.strict_ssl=true
         --auto-accept-invites
         --auto-respond-messages
@@ -154,7 +160,7 @@ services:
         --notify-revocation
         --plugin webvh
         --plugin-config-value webvh.witness=false
-        --plugin-config-value webvh.server_url=https://webvh
+        --plugin-config-value webvh.server_url=https://webvh.test
         --plugin-config-value webvh.strict_ssl=true
         --plugin-config-value webvh.endorsement=false
         --tails-server-base-url https://tails.anoncreds.vc
@@ -168,12 +174,12 @@ services:
       dockerfile: Dockerfile.test.runner
     environment:
       - WAIT_BEFORE=3
-      - WAIT_HOSTS=webvh:443, witness:3000, controller:3000, no_witness:3000
+      - WAIT_HOSTS=webvh.test:443, witness:3000, controller:3000, no_witness:3000
       - WAIT_TIMEOUT=90
       - WAIT_SLEEP_INTERVAL=1
       - WAIT_HOST_CONNECT_TIMEOUT=30
-      - WEBVH_DOMAIN=webvh
-      - WEBVH_SERVER_URL=https://webvh
+      - WEBVH_DOMAIN=webvh.test
+      - WEBVH_SERVER_URL=https://webvh.test
       - SSL_CERT_FILE=/certs/ca-bundle.pem
       - REQUESTS_CA_BUNDLE=/certs/ca-bundle.pem
     volumes:

--- a/webvh/integration/tests/constants.py
+++ b/webvh/integration/tests/constants.py
@@ -1,6 +1,6 @@
 from os import getenv
 
-WEBVH_DOMAIN = getenv("WEBVH_DOMAIN", "webvh")
+WEBVH_DOMAIN = getenv("WEBVH_DOMAIN", "webvh.test")
 WITNESS_SEED = "00000000000000000000000000000000"
 WITNESS_KEY = "z6MkgKA7yrw5kYSiDuQFcye4bMaJpcfHFry3Bx45pdWh3s8i"
 WITNESS_KID = f"webvh:{WEBVH_DOMAIN}@witnessKey"

--- a/webvh/integration/tests/constants.py
+++ b/webvh/integration/tests/constants.py
@@ -1,11 +1,11 @@
 from os import getenv
 
-WEBVH_DOMAIN = "sandbox.bcvh.vonx.io"
+WEBVH_DOMAIN = getenv("WEBVH_DOMAIN", "webvh")
 WITNESS_SEED = "00000000000000000000000000000000"
 WITNESS_KEY = "z6MkgKA7yrw5kYSiDuQFcye4bMaJpcfHFry3Bx45pdWh3s8i"
 WITNESS_KID = f"webvh:{WEBVH_DOMAIN}@witnessKey"
 WITNESS_ID = f"did:key:{WITNESS_KEY}"
-SERVER_URL = f"https://{WEBVH_DOMAIN}"
+SERVER_URL = getenv("WEBVH_SERVER_URL", f"https://{WEBVH_DOMAIN}")
 
 
 WITNESS = getenv("WITNESS", "http://witness:3001")

--- a/webvh/webvh/did/server_client.py
+++ b/webvh/webvh/did/server_client.py
@@ -1,5 +1,6 @@
 """A client for interacting with the WebVH server API."""
 
+import asyncio
 import http
 import json
 import logging
@@ -7,7 +8,13 @@ import logging
 from operator import itemgetter
 
 from acapy_agent.core.profile import Profile
-from aiohttp import ClientConnectionError, ClientResponseError, ClientSession
+from aiohttp import (
+    ClientConnectionError,
+    ClientResponseError,
+    ClientSession,
+    ClientTimeout,
+    ServerTimeoutError,
+)
 from did_webvh.core.state import DocumentState
 
 from ..config.config import get_server_url, use_strict_ssl
@@ -15,6 +22,35 @@ from .exceptions import DidCreationError, OperationError
 from .utils import all_are_not_none
 
 LOGGER = logging.getLogger(__name__)
+
+# Total wait sits above the common 30s proxy cut so we observe the reset, then
+# recover with GET rather than aborting while the server is still writing.
+HTTP_TIMEOUT = ClientTimeout(total=45, connect=10, sock_connect=10)
+
+
+def _already_exists(body) -> bool:
+    """Return True if a 409/error body reports a duplicate resource."""
+    if isinstance(body, dict):
+        detail = body.get("detail", body)
+        text = detail if isinstance(detail, str) else json.dumps(detail)
+    else:
+        text = str(body)
+    return "already exists" in text.lower()
+
+
+def _as_attested_resource(parsed, expected_id: str) -> dict | None:
+    """Return parsed JSON only if it is the attested resource for expected_id.
+
+    Empty objects, proxy 200s, and unrelated JSON must not count as a stored
+    resource (that would report STATE_FINISHED and 404 later).
+    """
+    if not expected_id or not isinstance(parsed, dict) or not parsed:
+        return None
+    if parsed.get("id") != expected_id:
+        return None
+    if not isinstance(parsed.get("content"), dict):
+        return None
+    return parsed
 
 
 class WebVHWatcherClient:
@@ -27,9 +63,10 @@ class WebVHWatcherClient:
     async def notify_watchers(self, did: str, watchers: str):
         """Notify watchers."""
 
-        async with ClientSession() as http_session:
+        async with ClientSession(timeout=HTTP_TIMEOUT) as http_session:
             for watcher in watchers:
-                await http_session.post(f"{watcher}/log?did={did}")
+                async with http_session.post(f"{watcher}/log?did={did}") as response:
+                    await response.read()
 
 
 class WebVHServerClient:
@@ -39,22 +76,44 @@ class WebVHServerClient:
         """Initialize the WebVHServerClient with a profile."""
         self.profile = profile
 
+    async def _ssl(self):
+        """SSL verification flag for outbound requests."""
+        return await use_strict_ssl(self.profile)
+
+    async def _read_response(self, response):
+        """Read response text once; parse JSON when advertised."""
+        raw = await response.text()
+        parsed = None
+        content_type = response.headers.get("Content-Type", "")
+        if "application/json" in content_type and raw:
+            try:
+                parsed = json.loads(raw)
+            except json.JSONDecodeError:
+                parsed = None
+        return raw, parsed
+
     async def request_identifier(self, namespace, identifier) -> tuple:
         """Contact the webvh server to request an identifier."""
-        async with ClientSession() as session:
+        async with ClientSession(timeout=HTTP_TIMEOUT) as session:
             try:
-                response = await session.get(
+                async with session.get(
                     await get_server_url(self.profile),
                     params={
                         "namespace": namespace,
                         "identifier": identifier,
                     },
-                    ssl=(await use_strict_ssl(self.profile)),
-                )
-            except ClientConnectionError as err:
-                raise DidCreationError(f"Failed to connect to Webvh server: {err}")
+                    ssl=(await self._ssl()),
+                ) as response:
+                    response_json = await response.json()
+            except (
+                ClientConnectionError,
+                asyncio.TimeoutError,
+                ServerTimeoutError,
+            ) as err:
+                raise DidCreationError(
+                    f"Failed to connect to Webvh server: {err}"
+                ) from err
 
-            response_json = await response.json()
             if (
                 response.status == http.HTTPStatus.BAD_REQUEST
                 or response.status == http.HTTPStatus.CONFLICT
@@ -80,19 +139,18 @@ class WebVHServerClient:
         """Submit a log entry to the WebVH server."""
         did = log_entry.get("state", {}).get("id")
         namespace, identifier = itemgetter(4, 5)(did.split(":"))
-        async with ClientSession() as session:
-            response = await session.post(
+        async with ClientSession(timeout=HTTP_TIMEOUT) as session:
+            async with session.post(
                 f"{await get_server_url(self.profile)}/{namespace}/{identifier}",
                 json={"logEntry": log_entry, "witnessSignature": witness_signature},
-                ssl=(await use_strict_ssl(self.profile)),
-            )
+                ssl=(await self._ssl()),
+            ) as response:
+                if response.status == http.HTTPStatus.INTERNAL_SERVER_ERROR:
+                    raise OperationError("Server had a problem creating log entry.")
 
-            if response.status == http.HTTPStatus.INTERNAL_SERVER_ERROR:
-                raise OperationError("Server had a problem creating log entry.")
-
-            response_json = await response.json()
-            if response.status == http.HTTPStatus.BAD_REQUEST:
-                raise OperationError(response_json.get("detail"))
+                response_json = await response.json()
+                if response.status == http.HTTPStatus.BAD_REQUEST:
+                    raise OperationError(response_json.get("detail"))
 
         did = log_entry.get("state", {}).get("id", None)
         if response_json.get("state", {}).get("id") != did:
@@ -103,9 +161,11 @@ class WebVHServerClient:
     async def fetch_jsonl(self, did: str):
         """Fetch a JSONL file from the given URL."""
         namespace, identifier = itemgetter(4, 5)(did.split(":"))
-        async with ClientSession() as session:
+        async with ClientSession(timeout=HTTP_TIMEOUT) as session:
             async with session.get(
-                f"{await get_server_url(self.profile)}/{namespace}/{identifier}/did.jsonl"
+                f"{await get_server_url(self.profile)}"
+                f"/{namespace}/{identifier}/did.jsonl",
+                ssl=(await self._ssl()),
             ) as response:
                 # Check if the response is OK
                 response.raise_for_status()
@@ -132,18 +192,22 @@ class WebVHServerClient:
         """Submit a whois Verifiable Presentation for a given identifier."""
         holder_id = vp.get("holder")
         namespace, identifier = itemgetter(4, 5)(holder_id.split(":"))
-        async with ClientSession() as http_session:
+        async with ClientSession(timeout=HTTP_TIMEOUT) as http_session:
             try:
-                response = await http_session.post(
+                async with http_session.post(
                     f"""
                     {await get_server_url(self.profile)}/{namespace}/{identifier}/whois
                     """,
                     json={"verifiablePresentation": vp},
-                )
-            except ClientConnectionError as err:
-                raise OperationError(f"Failed to connect to Webvh server: {err}")
-
-            return await response.json()
+                    ssl=(await self._ssl()),
+                ) as response:
+                    return await response.json()
+            except (
+                ClientConnectionError,
+                asyncio.TimeoutError,
+                ServerTimeoutError,
+            ) as err:
+                raise OperationError(f"Failed to connect to Webvh server: {err}") from err
 
     def _derive_update_url(self, server_url: str, resource_id: str) -> str:
         """Derive full URL for updating an existing resource. Uses server_url as base."""
@@ -157,11 +221,82 @@ class WebVHServerClient:
         base = server_url.rstrip("/")
         return f"{base}/{namespace}/{identifier}/resources/{digest}"
 
-    async def upload_attested_resource(self, resource: dict):
+    async def get_attested_resource(self, resource_id: str) -> dict | None:
+        """GET an attested resource by id.
+
+        Return the resource only when status is 200 and the body is that
+        resource (matching id and content). Empty or unrelated JSON is None.
+        """
+        if not resource_id:
+            return None
+        server_url = (await get_server_url(self.profile)).rstrip("/")
+        url = self._derive_update_url(server_url, resource_id)
+        try:
+            async with ClientSession(timeout=HTTP_TIMEOUT) as session:
+                async with session.get(url, ssl=(await self._ssl())) as response:
+                    if response.status == http.HTTPStatus.NOT_FOUND:
+                        return None
+                    if response.status == http.HTTPStatus.OK:
+                        _raw, parsed = await self._read_response(response)
+                        stored = _as_attested_resource(parsed, resource_id)
+                        if stored is None:
+                            LOGGER.warning(
+                                "GET 200 for attested resource %s was empty or "
+                                "not that resource; treating as missing",
+                                resource_id,
+                            )
+                        return stored
+                    LOGGER.warning(
+                        "Unexpected status %s fetching attested resource %s",
+                        response.status,
+                        resource_id,
+                    )
+                    return None
+        except (
+            ClientConnectionError,
+            asyncio.TimeoutError,
+            ServerTimeoutError,
+        ) as err:
+            LOGGER.warning("Failed to GET attested resource %s: %s", resource_id, err)
+            return None
+
+    async def _finish_upload_response(self, response, resource: dict):
+        """Interpret POST/PUT status: success, idempotent conflict, or error.
+
+        200/201 with a matching resource body succeed. Empty 200/201 and 409
+        succeed only after GET confirms the digest we signed.
+        """
+        resource_id = resource.get("id", "")
+        raw, parsed = await self._read_response(response)
+        if response.status in (http.HTTPStatus.OK, http.HTTPStatus.CREATED):
+            stored = _as_attested_resource(parsed, resource_id)
+            if stored is not None:
+                return stored
+            confirmed = await self.get_attested_resource(resource_id)
+            if confirmed is not None:
+                return confirmed
+            raise OperationError(
+                f"WebVH server error uploading attested resource: "
+                f"status={response.status} body={parsed if parsed is not None else raw}"
+            )
+        if response.status == http.HTTPStatus.CONFLICT or (
+            response.status >= 400
+            and _already_exists(parsed if parsed is not None else raw)
+        ):
+            confirmed = await self.get_attested_resource(resource_id)
+            if confirmed is not None:
+                return confirmed
+        raise OperationError(
+            f"WebVH server error uploading attested resource: "
+            f"status={response.status} body={parsed if parsed is not None else raw}"
+        )
+
+    async def upload_attested_resource(self, resource: dict, *, _replayed: bool = False):
         """Upload an attested resource.
 
         PUT for rev reg def updates (has links), else POST. Retries with PUT if POST
-        returns 500 (resource may already exist).
+        returns 500 (resource may already exist). On timeout, GET the digest then
+        replay the same payload once so ACA-Py does not mint a new resource id.
         """
         resource_id = resource.get("id", "")
         author_id = resource_id.split("/")[0]
@@ -180,30 +315,39 @@ class WebVHServerClient:
             },
         }
         post_url = f"{server_url}/{namespace}/{identifier}/resources"
+        ssl = await self._ssl()
 
-        async with ClientSession() as http_session:
-            try:
+        try:
+            async with ClientSession(timeout=HTTP_TIMEOUT) as http_session:
                 if use_put:
-                    response = await http_session.put(put_url, json=put_payload)
-                else:
-                    response = await http_session.post(
-                        post_url, json={"attestedResource": resource}
-                    )
-                    if response.status == 500:
-                        response = await http_session.put(put_url, json=put_payload)
-            except ClientConnectionError as err:
-                raise OperationError(f"Failed to connect to Webvh server: {err}")
-
-            if response.status >= 400:
-                body = await response.text()
-                try:
-                    if "application/json" in response.headers.get("Content-Type", ""):
-                        body = json.loads(body)
-                except (json.JSONDecodeError, TypeError):
-                    pass
-                raise OperationError(
-                    f"WebVH server error uploading attested resource: "
-                    f"status={response.status} body={body}"
+                    async with http_session.put(
+                        put_url, json=put_payload, ssl=ssl
+                    ) as response:
+                        return await self._finish_upload_response(response, resource)
+                async with http_session.post(
+                    post_url, json={"attestedResource": resource}, ssl=ssl
+                ) as response:
+                    if response.status == http.HTTPStatus.INTERNAL_SERVER_ERROR:
+                        async with http_session.put(
+                            put_url, json=put_payload, ssl=ssl
+                        ) as put_response:
+                            return await self._finish_upload_response(
+                                put_response, resource
+                            )
+                    return await self._finish_upload_response(response, resource)
+        except (
+            ClientConnectionError,
+            asyncio.TimeoutError,
+            ServerTimeoutError,
+        ) as err:
+            stored = await self.get_attested_resource(resource_id)
+            if stored is not None:
+                LOGGER.info(
+                    "Upload timed out but resource %s is present on the server",
+                    resource_id,
                 )
-            ct = response.headers.get("Content-Type", "")
-            return await response.json() if "application/json" in ct else {}
+                return stored
+            if not _replayed and not use_put:
+                LOGGER.info("Replaying attested resource POST for %s", resource_id)
+                return await self.upload_attested_resource(resource, _replayed=True)
+            raise OperationError(f"Failed to connect to Webvh server: {err}") from err

--- a/webvh/webvh/did/server_client.py
+++ b/webvh/webvh/did/server_client.py
@@ -25,7 +25,10 @@ LOGGER = logging.getLogger(__name__)
 
 # Total wait sits above the common 30s proxy cut so we observe the reset, then
 # recover with GET rather than aborting while the server is still writing.
-HTTP_TIMEOUT = ClientTimeout(total=45, connect=10, sock_connect=10)
+# Applied only to attested-resource GET/POST. A short connect cap fails TLS
+# against a slow sandbox (did.jsonl, identifier, whois) before the request
+# starts. Connect is left unbounded; aiohttp still honors total.
+RESOURCE_HTTP_TIMEOUT = ClientTimeout(total=45)
 
 
 def _already_exists(body) -> bool:
@@ -63,7 +66,7 @@ class WebVHWatcherClient:
     async def notify_watchers(self, did: str, watchers: str):
         """Notify watchers."""
 
-        async with ClientSession(timeout=HTTP_TIMEOUT) as http_session:
+        async with ClientSession() as http_session:
             for watcher in watchers:
                 async with http_session.post(f"{watcher}/log?did={did}") as response:
                     await response.read()
@@ -94,7 +97,7 @@ class WebVHServerClient:
 
     async def request_identifier(self, namespace, identifier) -> tuple:
         """Contact the webvh server to request an identifier."""
-        async with ClientSession(timeout=HTTP_TIMEOUT) as session:
+        async with ClientSession() as session:
             try:
                 async with session.get(
                     await get_server_url(self.profile),
@@ -139,7 +142,7 @@ class WebVHServerClient:
         """Submit a log entry to the WebVH server."""
         did = log_entry.get("state", {}).get("id")
         namespace, identifier = itemgetter(4, 5)(did.split(":"))
-        async with ClientSession(timeout=HTTP_TIMEOUT) as session:
+        async with ClientSession() as session:
             async with session.post(
                 f"{await get_server_url(self.profile)}/{namespace}/{identifier}",
                 json={"logEntry": log_entry, "witnessSignature": witness_signature},
@@ -161,7 +164,7 @@ class WebVHServerClient:
     async def fetch_jsonl(self, did: str):
         """Fetch a JSONL file from the given URL."""
         namespace, identifier = itemgetter(4, 5)(did.split(":"))
-        async with ClientSession(timeout=HTTP_TIMEOUT) as session:
+        async with ClientSession() as session:
             async with session.get(
                 f"{await get_server_url(self.profile)}"
                 f"/{namespace}/{identifier}/did.jsonl",
@@ -192,7 +195,7 @@ class WebVHServerClient:
         """Submit a whois Verifiable Presentation for a given identifier."""
         holder_id = vp.get("holder")
         namespace, identifier = itemgetter(4, 5)(holder_id.split(":"))
-        async with ClientSession(timeout=HTTP_TIMEOUT) as http_session:
+        async with ClientSession() as http_session:
             try:
                 async with http_session.post(
                     f"""
@@ -232,7 +235,7 @@ class WebVHServerClient:
         server_url = (await get_server_url(self.profile)).rstrip("/")
         url = self._derive_update_url(server_url, resource_id)
         try:
-            async with ClientSession(timeout=HTTP_TIMEOUT) as session:
+            async with ClientSession(timeout=RESOURCE_HTTP_TIMEOUT) as session:
                 async with session.get(url, ssl=(await self._ssl())) as response:
                     if response.status == http.HTTPStatus.NOT_FOUND:
                         return None
@@ -318,7 +321,7 @@ class WebVHServerClient:
         ssl = await self._ssl()
 
         try:
-            async with ClientSession(timeout=HTTP_TIMEOUT) as http_session:
+            async with ClientSession(timeout=RESOURCE_HTTP_TIMEOUT) as http_session:
                 if use_put:
                     async with http_session.put(
                         put_url, json=put_payload, ssl=ssl

--- a/webvh/webvh/did/tests/test_controller_manager.py
+++ b/webvh/webvh/did/tests/test_controller_manager.py
@@ -11,11 +11,12 @@ from acapy_agent.wallet.key_type import KeyTypes
 from acapy_agent.wallet.keys.manager import MultikeyManager
 
 from ...config.config import set_config
+from ...protocols.states import WitnessingState
+from ...protocols.log_entry.record import PendingLogEntryRecord
+from ...tests.fixtures import aiohttp_response_cm
 from ..manager import ControllerManager
 from ..witness import WitnessManager
 from ..exceptions import ConfigurationError
-from ...protocols.states import WitnessingState
-from ...protocols.log_entry.record import PendingLogEntryRecord
 
 SCID_PLACEHOLDER = "{SCID}"
 TEST_DOMAIN = "sandbox.bcvh.vonx.io"
@@ -163,12 +164,14 @@ class TestOperationsManager(IsolatedAsyncioTestCase):
     @mock.patch("asyncio.sleep", mock.AsyncMock())
     @mock.patch(
         "aiohttp.ClientSession.post",
-        mock.AsyncMock(
-            return_value=mock.MagicMock(
-                json=mock.AsyncMock(
-                    return_value={
-                        "state": {"id": TEST_DID},
-                    }
+        mock.MagicMock(
+            return_value=aiohttp_response_cm(
+                mock.MagicMock(
+                    json=mock.AsyncMock(
+                        return_value={
+                            "state": {"id": TEST_DID},
+                        }
+                    )
                 )
             )
         ),

--- a/webvh/webvh/did/tests/test_server_client.py
+++ b/webvh/webvh/did/tests/test_server_client.py
@@ -1,0 +1,265 @@
+"""Unit tests for WebVHServerClient attested resource upload recovery."""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import patch
+
+from aiohttp import ClientConnectionError
+from acapy_agent.utils.testing import create_test_profile
+
+from ...tests.fixtures import TEST_SERVER_URL
+from ..exceptions import OperationError
+from ..server_client import WebVHServerClient
+
+TEST_RESOURCE_ID = "did:webvh:QmScid:sandbox.bcvh.vonx.io:test:abc/resources/zQmDigestA"
+TEST_RESOURCE = {
+    "id": TEST_RESOURCE_ID,
+    "content": {"tag": "tag", "credDefId": "cred-def"},
+    "metadata": {
+        "resourceId": "zQmDigestA",
+        "resourceType": "anonCredsSchema",
+    },
+}
+STORED_RESOURCE = {**TEST_RESOURCE, "proof": {"type": "DataIntegrityProof"}}
+
+
+class _FakeResponse:
+    def __init__(self, status, payload=None, content_type="application/json"):
+        self.status = status
+        self._payload = payload if payload is not None else {}
+        self.headers = {"Content-Type": content_type} if content_type else {}
+
+    async def text(self):
+        import json
+
+        if isinstance(self._payload, str):
+            return self._payload
+        return json.dumps(self._payload)
+
+    async def json(self):
+        return self._payload
+
+    async def read(self):
+        return b""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _RaisingCM:
+    def __init__(self, exc):
+        self._exc = exc
+
+    async def __aenter__(self):
+        raise self._exc
+
+    async def __aexit__(self, exc_type, ext, tb):
+        return False
+
+
+class _FakeSession:
+    def __init__(self, handler):
+        self._handler = handler
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, **kwargs):
+        return self._handler("POST", url, kwargs)
+
+    def put(self, url, **kwargs):
+        return self._handler("PUT", url, kwargs)
+
+    def get(self, url, **kwargs):
+        return self._handler("GET", url, kwargs)
+
+
+class TestUploadAttestedResource(IsolatedAsyncioTestCase):
+    async def asyncSetUp(self):
+        self.profile = await create_test_profile({"wallet.type": "askar-anoncreds"})
+        self.profile.settings.set_value(
+            "plugin_config", {"webvh": {"server_url": TEST_SERVER_URL}}
+        )
+        self.client = WebVHServerClient(self.profile)
+        self.calls = []
+
+    def _patch_session(self, handler):
+        return patch(
+            "webvh.did.server_client.ClientSession",
+            side_effect=lambda *args, **kwargs: _FakeSession(handler),
+        )
+
+    async def test_timeout_then_get_200_returns_stored_resource(self):
+        def handler(method, url, kwargs):
+            self.calls.append(method)
+            if method == "POST":
+                return _RaisingCM(ClientConnectionError("Connection timeout to host"))
+            if method == "GET":
+                return _FakeResponse(200, STORED_RESOURCE)
+            raise AssertionError(f"unexpected {method} {url}")
+
+        with self._patch_session(handler):
+            result = await self.client.upload_attested_resource(TEST_RESOURCE)
+
+        assert result == STORED_RESOURCE
+        assert self.calls == ["POST", "GET"]
+
+    async def test_timeout_then_get_404_replays_post(self):
+        posts = {"n": 0}
+
+        def handler(method, url, kwargs):
+            self.calls.append(method)
+            if method == "POST":
+                posts["n"] += 1
+                if posts["n"] == 1:
+                    return _RaisingCM(ClientConnectionError("Connection timeout to host"))
+                return _FakeResponse(201, STORED_RESOURCE)
+            if method == "GET":
+                return _FakeResponse(404, {"detail": "not found"})
+            raise AssertionError(f"unexpected {method} {url}")
+
+        with self._patch_session(handler):
+            result = await self.client.upload_attested_resource(TEST_RESOURCE)
+
+        assert result == STORED_RESOURCE
+        assert self.calls == ["POST", "GET", "POST"]
+
+    async def test_post_409_already_exists_returns_stored_resource(self):
+        def handler(method, url, kwargs):
+            self.calls.append(method)
+            if method == "POST":
+                return _FakeResponse(
+                    409, {"detail": "Resource already exists with ID 'zQmDigestA'."}
+                )
+            if method == "GET":
+                return _FakeResponse(200, STORED_RESOURCE)
+            raise AssertionError(f"unexpected {method} {url}")
+
+        with self._patch_session(handler):
+            result = await self.client.upload_attested_resource(TEST_RESOURCE)
+
+        assert result == STORED_RESOURCE
+        assert self.calls == ["POST", "GET"]
+
+    async def test_post_500_falls_back_to_put(self):
+        def handler(method, url, kwargs):
+            self.calls.append(method)
+            if method == "POST":
+                return _FakeResponse(500, {"detail": "internal"})
+            if method == "PUT":
+                return _FakeResponse(200, STORED_RESOURCE)
+            raise AssertionError(f"unexpected {method} {url}")
+
+        with self._patch_session(handler):
+            result = await self.client.upload_attested_resource(TEST_RESOURCE)
+
+        assert result == STORED_RESOURCE
+        assert self.calls == ["POST", "PUT"]
+
+    async def test_timeout_get_404_replay_fails_raises(self):
+        def handler(method, url, kwargs):
+            self.calls.append(method)
+            if method == "POST":
+                return _RaisingCM(ClientConnectionError("Connection timeout to host"))
+            if method == "GET":
+                return _FakeResponse(404, {"detail": "not found"})
+            raise AssertionError(f"unexpected {method} {url}")
+
+        with self._patch_session(handler):
+            with self.assertRaises(OperationError):
+                await self.client.upload_attested_resource(TEST_RESOURCE)
+
+        assert self.calls[0] == "POST"
+        assert "GET" in self.calls
+
+    async def test_timeout_then_empty_get_200_does_not_count_as_success(self):
+        posts = {"n": 0}
+
+        def handler(method, url, kwargs):
+            self.calls.append(method)
+            if method == "POST":
+                posts["n"] += 1
+                if posts["n"] == 1:
+                    return _RaisingCM(ClientConnectionError("Connection timeout to host"))
+                return _FakeResponse(201, STORED_RESOURCE)
+            if method == "GET":
+                return _FakeResponse(200, {})
+            raise AssertionError(f"unexpected {method} {url}")
+
+        with self._patch_session(handler):
+            result = await self.client.upload_attested_resource(TEST_RESOURCE)
+
+        assert result == STORED_RESOURCE
+        assert self.calls == ["POST", "GET", "POST"]
+
+    async def test_timeout_then_wrong_json_get_200_does_not_count_as_success(self):
+        posts = {"n": 0}
+
+        def handler(method, url, kwargs):
+            self.calls.append(method)
+            if method == "POST":
+                posts["n"] += 1
+                if posts["n"] == 1:
+                    return _RaisingCM(ClientConnectionError("Connection timeout to host"))
+                return _FakeResponse(201, STORED_RESOURCE)
+            if method == "GET":
+                return _FakeResponse(200, {"detail": "ok", "id": "not-the-resource"})
+            raise AssertionError(f"unexpected {method} {url}")
+
+        with self._patch_session(handler):
+            result = await self.client.upload_attested_resource(TEST_RESOURCE)
+
+        assert result == STORED_RESOURCE
+        assert self.calls == ["POST", "GET", "POST"]
+
+    async def test_post_409_get_404_raises(self):
+        def handler(method, url, kwargs):
+            self.calls.append(method)
+            if method == "POST":
+                return _FakeResponse(
+                    409, {"detail": "Resource already exists with ID 'zQmDigestA'."}
+                )
+            if method == "GET":
+                return _FakeResponse(404, {"detail": "not found"})
+            raise AssertionError(f"unexpected {method} {url}")
+
+        with self._patch_session(handler):
+            with self.assertRaises(OperationError):
+                await self.client.upload_attested_resource(TEST_RESOURCE)
+
+        assert self.calls == ["POST", "GET"]
+
+    async def test_post_201_empty_body_succeeds_only_after_get_confirms(self):
+        def handler(method, url, kwargs):
+            self.calls.append(method)
+            if method == "POST":
+                return _FakeResponse(201, {})
+            if method == "GET":
+                return _FakeResponse(200, STORED_RESOURCE)
+            raise AssertionError(f"unexpected {method} {url}")
+
+        with self._patch_session(handler):
+            result = await self.client.upload_attested_resource(TEST_RESOURCE)
+
+        assert result == STORED_RESOURCE
+        assert self.calls == ["POST", "GET"]
+
+    async def test_post_201_empty_body_get_empty_raises(self):
+        def handler(method, url, kwargs):
+            self.calls.append(method)
+            if method == "POST":
+                return _FakeResponse(201, {})
+            if method == "GET":
+                return _FakeResponse(200, {})
+            raise AssertionError(f"unexpected {method} {url}")
+
+        with self._patch_session(handler):
+            with self.assertRaises(OperationError):
+                await self.client.upload_attested_resource(TEST_RESOURCE)
+
+        assert self.calls == ["POST", "GET"]

--- a/webvh/webvh/did/tests/test_server_client.py
+++ b/webvh/webvh/did/tests/test_server_client.py
@@ -263,3 +263,52 @@ class TestUploadAttestedResource(IsolatedAsyncioTestCase):
                 await self.client.upload_attested_resource(TEST_RESOURCE)
 
         assert self.calls == ["POST", "GET"]
+
+    async def test_resource_session_uses_total_timeout_without_connect_cap(self):
+        captured = []
+
+        def handler(method, url, kwargs):
+            self.calls.append(method)
+            if method == "POST":
+                return _FakeResponse(201, STORED_RESOURCE)
+            raise AssertionError(f"unexpected {method} {url}")
+
+        def session_factory(*args, **kwargs):
+            captured.append(kwargs)
+            return _FakeSession(handler)
+
+        with patch(
+            "webvh.did.server_client.ClientSession",
+            side_effect=session_factory,
+        ):
+            await self.client.upload_attested_resource(TEST_RESOURCE)
+
+        assert captured
+        timeout = captured[0].get("timeout")
+        assert timeout is not None
+        assert timeout.total == 45
+        assert timeout.connect is None
+        assert timeout.sock_connect is None
+
+    async def test_did_identifier_session_has_no_timeout(self):
+        captured = []
+        payload = {
+            "parameters": {"method": "webvh", "proof": {"type": "DataIntegrityProof"}},
+            "state": {"id": "did:webvh:QmScid:sandbox.bcvh.vonx.io:test:abc"},
+        }
+
+        def handler(method, url, kwargs):
+            return _FakeResponse(200, payload)
+
+        def session_factory(*args, **kwargs):
+            captured.append(kwargs)
+            return _FakeSession(handler)
+
+        with patch(
+            "webvh.did.server_client.ClientSession",
+            side_effect=session_factory,
+        ):
+            await self.client.request_identifier("test", "abc")
+
+        assert captured
+        assert "timeout" not in captured[0]

--- a/webvh/webvh/protocols/attested_resource/tests/test_protocol.py
+++ b/webvh/webvh/protocols/attested_resource/tests/test_protocol.py
@@ -1,4 +1,5 @@
 from unittest import IsolatedAsyncioTestCase
+import json
 import uuid
 
 from acapy_agent.connections.models.conn_record import ConnRecord
@@ -15,7 +16,7 @@ from ..handlers import WitnessRequestHandler, WitnessResponseHandler
 from ..record import PendingAttestedResourceRecord
 from ..messages import WitnessRequest, WitnessResponse
 from ...states import WitnessingState
-from ....tests.fixtures import TEST_RESOLVER
+from ....tests.fixtures import TEST_RESOLVER, aiohttp_response_cm
 
 record = PendingAttestedResourceRecord()
 
@@ -127,18 +128,28 @@ class TestAttestedResourceProtocol(IsolatedAsyncioTestCase):
 
     @mock.patch(
         "aiohttp.ClientSession.post",
-        mock.AsyncMock(
-            return_value=mock.MagicMock(
-                status=200,
-                headers={"Content-Type": "application/json"},
-                json=mock.AsyncMock(
-                    return_value={
-                        "id": TEST_RESOURCE_ID,
-                        "content": {},
-                        "proof": {},
-                    }
-                ),
-                text=mock.AsyncMock(return_value="{}"),
+        mock.MagicMock(
+            return_value=aiohttp_response_cm(
+                mock.MagicMock(
+                    status=200,
+                    headers={"Content-Type": "application/json"},
+                    json=mock.AsyncMock(
+                        return_value={
+                            "id": TEST_RESOURCE_ID,
+                            "content": {"schema_name": "Test Schema"},
+                            "proof": {},
+                        }
+                    ),
+                    text=mock.AsyncMock(
+                        return_value=json.dumps(
+                            {
+                                "id": TEST_RESOURCE_ID,
+                                "content": {"schema_name": "Test Schema"},
+                                "proof": {},
+                            }
+                        )
+                    ),
+                )
             )
         ),
     )

--- a/webvh/webvh/protocols/log_entry/tests/test_protocol.py
+++ b/webvh/webvh/protocols/log_entry/tests/test_protocol.py
@@ -11,7 +11,7 @@ from acapy_agent.utils.testing import create_test_profile
 from acapy_agent.wallet.keys.manager import MultikeyManager
 from acapy_agent.wallet.key_type import KeyTypes
 
-from ....tests.fixtures import TEST_RESOLVER
+from ....tests.fixtures import TEST_RESOLVER, aiohttp_response_cm
 from ...states import WitnessingState
 from ....config.config import set_config
 from ..handlers import WitnessRequestHandler, WitnessResponseHandler
@@ -79,12 +79,14 @@ class TestLogEntryProtocol(IsolatedAsyncioTestCase):
 
     @mock.patch(
         "aiohttp.ClientSession.post",
-        mock.AsyncMock(
-            return_value=mock.MagicMock(
-                json=mock.AsyncMock(
-                    return_value={
-                        "state": {"id": TEST_DID},
-                    }
+        mock.MagicMock(
+            return_value=aiohttp_response_cm(
+                mock.MagicMock(
+                    json=mock.AsyncMock(
+                        return_value={
+                            "state": {"id": TEST_DID},
+                        }
+                    )
                 )
             )
         ),

--- a/webvh/webvh/tests/fixtures.py
+++ b/webvh/webvh/tests/fixtures.py
@@ -21,3 +21,11 @@ TEST_RESOLVER.resolve_with_metadata = mock.AsyncMock(
         ),
     )
 )
+
+
+def aiohttp_response_cm(response):
+    """Return an async context manager that yields a mocked aiohttp response."""
+    cm = mock.MagicMock()
+    cm.__aenter__ = mock.AsyncMock(return_value=response)
+    cm.__aexit__ = mock.AsyncMock(return_value=False)
+    return cm


### PR DESCRIPTION
## Summary
- After a hung `POST /resources`, GET the digest this agent already signed and treat a real matching resource (`id` + `content`) as success so ACA-Py revocation auto-recovery does not mint a second registry.
- If GET is 404 or a bogus 200 (empty/unrelated JSON), replay the **same** payload once. HTTP 409 `"already exists"` succeeds only after that GET confirm.
- Close unclosed aiohttp responses and set a 45s total / 10s connect timeout so the client observes a ~30s proxy cut, then recovers via GET rather than aborting mid-write.

## Test plan
- [ ] `cd webvh && poetry run pytest webvh/did/tests/test_server_client.py`
- [ ] Confirm timeout + GET 200 with a matching resource does not raise
- [ ] Confirm empty GET 200 / wrong JSON does **not** count as published (replay or raise)
- [ ] Confirm 409 without a confirming GET raises
- [ ] Confirm POST 500 still falls back to PUT