### PR TITLE
test(webvh): run integration against a local didwebvh-server

### DIFF
--- a/webvh/integration/caddy/Caddyfile
+++ b/webvh/integration/caddy/Caddyfile
@@ -1,0 +1,8 @@
+{
+	auto_https disable_redirects
+}
+
+webvh.test:443 {
+	tls /certs/webvh.crt /certs/webvh.key
+	reverse_proxy webvh-server:8000
+}

--- a/webvh/integration/certs/entrypoint.sh
+++ b/webvh/integration/certs/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+apk add --no-cache openssl ca-certificates >/dev/null
+openssl req -x509 -newkey rsa:2048 -sha256 -days 2 -nodes \
+  -keyout /certs/webvh.key \
+  -out /certs/webvh.crt \
+  -subj "/CN=webvh.test" \
+  -addext "subjectAltName=DNS:webvh.test"
+chmod 644 /certs/webvh.crt /certs/webvh.key
+cat /etc/ssl/certs/ca-certificates.crt /certs/webvh.crt > /certs/ca-bundle.pem
+chmod 644 /certs/ca-bundle.pem
+# Stay up: compose --exit-code-from tests aborts if any service exits.
+exec tail -f /dev/null

--- a/webvh/integration/docker-compose.yml
+++ b/webvh/integration/docker-compose.yml
@@ -1,11 +1,96 @@
+# Local WebVH server (not sandbox.bcvh.vonx.io).
+# did:webvh resolution is HTTPS-only, so Caddy terminates TLS.
+# Hostname must be two DNS labels (did_webvh DomainPath.validate); "webvh" is rejected.
+# Agents trust the test CA via SSL_CERT_FILE (bundle includes public CAs for tails).
+
+x-plugin-agent: &plugin-agent
+  image: plugin-image
+  build:
+    context: ..
+    dockerfile: docker/Dockerfile
+    args:
+      - install_flags=--no-interaction --with integration --extras aca-py
+  environment:
+    SSL_CERT_FILE: /certs/ca-bundle.pem
+    REQUESTS_CA_BUNDLE: /certs/ca-bundle.pem
+    CURL_CA_BUNDLE: /certs/ca-bundle.pem
+  volumes:
+    - webvh-certs:/certs:ro
+  depends_on:
+    webvh-certs:
+      condition: service_healthy
+    webvh-server:
+      condition: service_healthy
+    webvh:
+      condition: service_healthy
+
 services:
+  webvh-certs:
+    image: alpine:3.21
+    volumes:
+      - webvh-certs:/certs
+      - ./certs/entrypoint.sh:/entrypoint.sh:ro
+    entrypoint: ["/bin/sh", "/entrypoint.sh"]
+    healthcheck:
+      test: ["CMD", "test", "-f", "/certs/ca-bundle.pem"]
+      interval: 2s
+      timeout: 2s
+      retries: 20
+      start_period: 5s
+
+  webvh-server:
+    image: ghcr.io/decentralized-identity/didwebvh-server-py:0.5.0
+    environment:
+      WEBVH_DOMAIN: webvh.test
+      APP_PORT: "8000"
+      APP_WORKERS: "1"
+      WEBVH_WITNESS: "false"
+      WEBVH_PREROTATION: "false"
+      WEBVH_PORTABILITY: "false"
+      WEBVH_ENDORSEMENT: "false"
+      ENABLE_TAILS: "false"
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "python3 -c \"import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/api/server/status')\"",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 20s
+    depends_on:
+      webvh-certs:
+        condition: service_healthy
+
+  webvh:
+    image: caddy:2-alpine
+    hostname: webvh.test
+    networks:
+      default:
+        aliases:
+          - webvh.test
+    volumes:
+      - webvh-certs:/certs:ro
+      - ./caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "wget -qO- http://webvh-server:8000/api/server/status | grep -q ok",
+        ]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 5s
+    depends_on:
+      webvh-certs:
+        condition: service_healthy
+      webvh-server:
+        condition: service_healthy
+
   witness:
-    image: plugin-image
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile
-      args:
-        - install_flags=--no-interaction --with integration --extras aca-py
+    <<: *plugin-agent
     command: >
       start
         --label Witness
@@ -23,7 +108,8 @@ services:
         --notify-revocation
         --plugin webvh
         --plugin-config-value webvh.witness=true
-        --plugin-config-value webvh.server_url=https://sandbox.bcvh.vonx.io
+        --plugin-config-value webvh.server_url=https://webvh.test
+        --plugin-config-value webvh.strict_ssl=true
         --tails-server-base-url https://tails.anoncreds.vc
         --auto-provision
         --seed 00000000000000000000000000000000
@@ -32,12 +118,7 @@ services:
         --auto-respond-messages
 
   controller:
-    image: plugin-image
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile
-      args:
-        - install_flags=--no-interaction --with integration --extras aca-py
+    <<: *plugin-agent
     command: >
       start
         --label Controller
@@ -55,17 +136,13 @@ services:
         --monitor-revocation-notification
         --plugin webvh
         --plugin-config-value webvh.witness=false
-        --plugin-config-value webvh.server_url=https://sandbox.bcvh.vonx.io
+        --plugin-config-value webvh.server_url=https://webvh.test
+        --plugin-config-value webvh.strict_ssl=true
         --auto-accept-invites
         --auto-respond-messages
 
   no_witness:
-    image: plugin-image
-    build:
-      context: ..
-      dockerfile: docker/Dockerfile
-      args:
-        - install_flags=--no-interaction --with integration --extras aca-py
+    <<: *plugin-agent
     command: >
       start
         --label NoWitness
@@ -83,24 +160,41 @@ services:
         --notify-revocation
         --plugin webvh
         --plugin-config-value webvh.witness=false
-        --plugin-config-value webvh.server_url=https://sandbox.bcvh.vonx.io
+        --plugin-config-value webvh.server_url=https://webvh.test
+        --plugin-config-value webvh.strict_ssl=true
         --plugin-config-value webvh.endorsement=false
         --tails-server-base-url https://tails.anoncreds.vc
         --auto-accept-invites
         --auto-respond-messages
 
   tests:
-      container_name: juggernaut
-      build:
-        context: .
-        dockerfile: Dockerfile.test.runner
-      environment:
-        - WAIT_BEFORE=3
-        - WAIT_HOSTS=witness:3000, controller:3000, no_witness:3000
-        - WAIT_TIMEOUT=60
-        - WAIT_SLEEP_INTERVAL=1
-        - WAIT_HOST_CONNECT_TIMEOUT=30
-      depends_on:
-        - witness
-        - controller
-        - no_witness
+    container_name: juggernaut
+    build:
+      context: .
+      dockerfile: Dockerfile.test.runner
+    environment:
+      - WAIT_BEFORE=3
+      - WAIT_HOSTS=webvh.test:443, witness:3000, controller:3000, no_witness:3000
+      - WAIT_TIMEOUT=90
+      - WAIT_SLEEP_INTERVAL=1
+      - WAIT_HOST_CONNECT_TIMEOUT=30
+      - WEBVH_DOMAIN=webvh.test
+      - WEBVH_SERVER_URL=https://webvh.test
+      - SSL_CERT_FILE=/certs/ca-bundle.pem
+      - REQUESTS_CA_BUNDLE=/certs/ca-bundle.pem
+    volumes:
+      - webvh-certs:/certs:ro
+    depends_on:
+      webvh-certs:
+        condition: service_healthy
+      webvh:
+        condition: service_healthy
+      witness:
+        condition: service_started
+      controller:
+        condition: service_started
+      no_witness:
+        condition: service_started
+
+volumes:
+  webvh-certs:

--- a/webvh/integration/tests/constants.py
+++ b/webvh/integration/tests/constants.py
@@ -1,11 +1,11 @@
 from os import getenv
 
-WEBVH_DOMAIN = "sandbox.bcvh.vonx.io"
+WEBVH_DOMAIN = getenv("WEBVH_DOMAIN", "webvh.test")
 WITNESS_SEED = "00000000000000000000000000000000"
 WITNESS_KEY = "z6MkgKA7yrw5kYSiDuQFcye4bMaJpcfHFry3Bx45pdWh3s8i"
 WITNESS_KID = f"webvh:{WEBVH_DOMAIN}@witnessKey"
 WITNESS_ID = f"did:key:{WITNESS_KEY}"
-SERVER_URL = f"https://{WEBVH_DOMAIN}"
+SERVER_URL = getenv("WEBVH_SERVER_URL", f"https://{WEBVH_DOMAIN}")
 
 
 WITNESS = getenv("WITNESS", "http://witness:3001")


### PR DESCRIPTION
## Summary
- Stop webvh integration tests from depending on the shared `sandbox.bcvh.vonx.io` instance (CPU-throttled, ~30s OpenShift route).
- Run `didwebvh-server-py:0.5.0` in compose, with Caddy TLS for `webvh.test` (two DNS labels so `did_webvh` will resolve) and a test CA that still includes public CAs for `tails.anoncreds.vc`.
- Keep the cert generator running so `docker compose up --exit-code-from tests` does not abort when the Alpine container would otherwise exit 0.

This is the compose/CI provisioning only. Plugin behavior is unchanged.

## Test plan
- [ ] Integration Tests workflow for `webvh` is green
- [ ] DID create/update/deactivate and witness protocol tests resolve `did:webvh:…:webvh.test:…`
- [ ] AnonCreds schema / cred-def / rev-reg flow still passes against the local server
- [ ] No plugin source under `webvh/webvh/` is in this diff