### PR TITLE
fix: express dependency update breaks oid4vc frontend

### DIFF
--- a/oid4vc/demo/frontend/index.js
+++ b/oid4vc/demo/frontend/index.js
@@ -1651,7 +1651,7 @@ app.post("/issue", (req, res, next) => {
   // webhooks showcase the current state of ACA-Py flows and can be acted upon to
   // give users up-to-date and realtime info.
 
-    app.post("/webhook/*", (req, res, next) => {
+    app.post("/webhook/*topic", (req, res, next) => {
       logger.trace("Webhook received");
       logger.trace(req.path);
       logger.trace(JSON.stringify(req.body));


### PR DESCRIPTION
Express 5.x do not accepts willdcards like * (see https://github.com/pillarjs/path-to-regexp#express--4x). This change came from dependa-bot pr #3451

