### PR TITLE
mDL Revocation Support

### DIFF
--- a/oid4vc/auth_server/docker/entrypoint.sh
+++ b/oid4vc/auth_server/docker/entrypoint.sh
@@ -40,29 +40,35 @@ TUNNEL_ENDPOINT=${TUNNEL_ENDPOINT:-http://ngrok:4040}
 WAIT_INTERVAL=${WAIT_INTERVAL:-3}
 WAIT_ATTEMPTS=${WAIT_ATTEMPTS:-10}
 
-liveliness_check () {
-        set -o pipefail
-        for CURRENT_ATTEMPT in $(seq 1 "$WAIT_ATTEMPTS"); do
-                # Use jq to check if the 'issuer' tunnel is available
-                if curl -sf "${1}/api/tunnels" | jq -e 'any(.tunnels[]; .name == "authserver" and .public_url != null)' > /dev/null; then
-                        break
-                else
-                        if [[ $CURRENT_ATTEMPT -ge $WAIT_ATTEMPTS ]]; then
-                                echo "Failed while waiting for 'issuer' tunnel in ${1}/api/tunnels"
-                                exit 1
+# If TENANT_ISSUER_BASE_URL is already provided (for example when using zrok),
+# skip the ngrok introspection and use the provided URL.
+if [[ -z "${TENANT_ISSUER_BASE_URL:-}" ]]; then
+        liveliness_check () {
+                set -o pipefail
+                for CURRENT_ATTEMPT in $(seq 1 "$WAIT_ATTEMPTS"); do
+                        # Use jq to check if the 'authserver' tunnel is available
+                        if curl -sf "${1}/api/tunnels" | jq -e 'any(.tunnels[]; .name == "authserver" and .public_url != null)' > /dev/null; then
+                                break
+                        else
+                                if [[ $CURRENT_ATTEMPT -ge $WAIT_ATTEMPTS ]]; then
+                                        echo "Failed while waiting for 'authserver' tunnel in ${1}/api/tunnels"
+                                        exit 1
+                                fi
+                                echo "Waiting for 'authserver' tunnel..." 1>&2
+                                sleep "$WAIT_INTERVAL" &
+                                wait $!
                         fi
-                        echo "Waiting for 'issuer' tunnel..." 1>&2
-                        sleep "$WAIT_INTERVAL" &
-                        wait $!
-                fi
-        done
-}
+                done
+        }
 
-liveliness_check "${TUNNEL_ENDPOINT}"
+        liveliness_check "${TUNNEL_ENDPOINT}"
 
-# Get the authserver tunnel public URL using jq
-export TENANT_ISSUER_BASE_URL=$(curl --silent "${TUNNEL_ENDPOINT}/api/tunnels" | jq -r '.tunnels[] | select(.name == "authserver") | .public_url')
-echo "TENANT_ISSUER_BASE_URL: $TENANT_ISSUER_BASE_URL"
+        # Get the authserver tunnel public URL using jq
+        export TENANT_ISSUER_BASE_URL=$(curl --silent "${TUNNEL_ENDPOINT}/api/tunnels" | jq -r '.tunnels[] | select(.name == "authserver") | .public_url')
+        echo "TENANT_ISSUER_BASE_URL (discovered): $TENANT_ISSUER_BASE_URL"
+else
+        echo "TENANT_ISSUER_BASE_URL (from env): $TENANT_ISSUER_BASE_URL"
+fi
 
 # Run Alembic migrations
 echo $PWD

--- a/oid4vc/demo/README.md
+++ b/oid4vc/demo/README.md
@@ -58,6 +58,14 @@ Before running the zrok variant, you need to set up three persistent tunnel shar
    docker compose --env-file env.zrok.example -f docker-compose-zrok.yaml up
    ```
 
+If you tear the stack down with `docker compose -f docker-compose-zrok.yaml down -v` and Docker later reports a missing network on restart, bring the stack back up with the same compose file and force recreation:
+
+```bash
+docker compose --env-file env.zrok.example -f docker-compose-zrok.yaml up --force-recreate --remove-orphans
+```
+
+That rebuilds any stale containers that were still pointing at the removed compose network.
+
 The reserved shares will create stable public URLs (based on your unique names), for example:
 - `https://myteam-oid4vc-issuer.share.zrok.io` → demo issuer
 - `https://myteam-oid4vc-authserver.share.zrok.io` → auth-server

--- a/oid4vc/demo/README.md
+++ b/oid4vc/demo/README.md
@@ -13,6 +13,58 @@ docker compose up
 
 **Important** The ngrok config only works with the paid version
 
+If you want to try the lightweight zrok draft instead of ngrok, copy `env.zrok.example` to `.env` and run the alternate compose file:
+
+```bash
+cp env.zrok.example .env
+docker compose -f docker-compose-zrok.yaml up
+```
+
+The zrok draft keeps the existing ngrok setup in `docker-compose.yaml` untouched. It assumes you have already reserved stable zrok names for issuer, auth-server, and demo frontend.
+
+#### Setting up zrok Shares
+
+Before running the zrok variant, you need to set up three persistent tunnel shares using the zrok CLI. This is a one-time setup per machine.
+
+1. **Install zrok** (if not already installed):
+   ```bash
+   # On macOS with Homebrew
+   brew install zrok
+   
+   # Or download from https://github.com/openziti/zrok/releases
+   ```
+
+2. **Authenticate with zrok**:
+   ```bash
+   zrok enable <your-zrok-token>
+   ```
+   You can get a free zrok account and token at https://zrok.io
+
+3. **Reserve the three tunnel shares** (run these commands once):
+   `--unique-name` values are globally unique in zrok's public namespace. Pick names that are unlikely to collide (for example, include your org/user/project prefix).
+   ```bash
+   # Reserve the issuer endpoint (points to demo issuer on port 8082)
+   zrok reserve public --unique-name myteamoid4vcissuer http://localhost:8082
+   
+   # Reserve the auth-server endpoint (points to auth-server on port 9001)
+   zrok reserve public --unique-name myteamoid4vcauthserver http://localhost:9001
+   
+   # Reserve the demo app endpoint (points to demo-app on port 3000)
+   zrok reserve public --unique-name myteamoid4vcdemo http://localhost:3000
+   ```
+
+4. **Run the demo with zrok**:
+   ```bash
+   docker compose --env-file env.zrok.example -f docker-compose-zrok.yaml up
+   ```
+
+The reserved shares will create stable public URLs (based on your unique names), for example:
+- `https://myteam-oid4vc-issuer.share.zrok.io` → demo issuer
+- `https://myteam-oid4vc-authserver.share.zrok.io` → auth-server
+- `https://myteam-oid4vc-demo.share.zrok.io` → demo app frontend
+
+Set the same names in `ISSUER_ZROK_NAME`, `AUTHSERVER_ZROK_NAME`, and `DEMO_ZROK_NAME` in your `.env` file, and update `OID4VCI_ENDPOINT`, `TENANT_ISSUER_BASE_URL`, and `AUTHSERVER_NGROK_URL` to match the resulting URLs.
+
 ### Demo Functionality
 
 * Issue credentials via OpendID4VCI 1.0 - JWT, SD-JWT and mDOC

--- a/oid4vc/demo/README.md
+++ b/oid4vc/demo/README.md
@@ -71,7 +71,11 @@ The reserved shares will create stable public URLs (based on your unique names),
 - `https://myteam-oid4vc-authserver.share.zrok.io` → auth-server
 - `https://myteam-oid4vc-demo.share.zrok.io` → demo app frontend
 
-Set the same names in `ISSUER_ZROK_NAME`, `AUTHSERVER_ZROK_NAME`, and `DEMO_ZROK_NAME` in your `.env` file, and update `OID4VCI_ENDPOINT`, `TENANT_ISSUER_BASE_URL`, and `AUTHSERVER_NGROK_URL` to match the resulting URLs.
+Set the same names in `ISSUER_ZROK_NAME`, `AUTHSERVER_ZROK_NAME`, and `DEMO_ZROK_NAME` in your `.env` file, and update `OID4VCI_ENDPOINT`, `TENANT_ISSUER_BASE_URL`, `AUTHSERVER_NGROK_URL`, and `DEMO_PUBLIC_URL` to match the resulting URLs.
+
+#### zrok Reliability
+
+zrok's reserved-share agent can silently lose its underlying OpenZiti circuit while still reporting the share as "active" ([openziti/zrok#1259](https://github.com/openziti/zrok/issues/1259)). Since the container never crashes, Docker's own restart policy won't recover it, and requests will start failing with a `502` from the zrok edge with no other visible symptom. The `zrok-watchdog` service in `docker-compose-zrok.yaml` polls each share's public URL and restarts the affected container when it stops answering. Make sure `DEMO_PUBLIC_URL` (in addition to the other public URL variables above) is set to your actual reserved domain, or the watchdog will poll the wrong URL for the demo share.
 
 ### Demo Functionality
 

--- a/oid4vc/demo/README.md
+++ b/oid4vc/demo/README.md
@@ -71,7 +71,7 @@ The reserved shares will create stable public URLs (based on your unique names),
 - `https://myteam-oid4vc-authserver.share.zrok.io` → auth-server
 - `https://myteam-oid4vc-demo.share.zrok.io` → demo app frontend
 
-Set the same names in `ISSUER_ZROK_NAME`, `AUTHSERVER_ZROK_NAME`, and `DEMO_ZROK_NAME` in your `.env` file, and update `OID4VCI_ENDPOINT`, `TENANT_ISSUER_BASE_URL`, `AUTHSERVER_NGROK_URL`, and `DEMO_PUBLIC_URL` to match the resulting URLs.
+Set the same names in `ISSUER_ZROK_NAME`, `AUTHSERVER_ZROK_NAME`, and `DEMO_ZROK_NAME` in your `.env` file, and update `OID4VCI_ENDPOINT`, `TENANT_ISSUER_BASE_URL`, and `DEMO_PUBLIC_URL` to match the resulting URLs (the demo app's own public auth-server URL is derived from `TENANT_ISSUER_BASE_URL`, no separate variable needed).
 
 #### zrok Reliability
 

--- a/oid4vc/demo/docker-compose-zrok.yaml
+++ b/oid4vc/demo/docker-compose-zrok.yaml
@@ -204,7 +204,10 @@ services:
       API_BASE_URL: http://issuer:3001
       FORCE_COLOR: 3
       ADMIN_MANAGE_AUTH_TOKEN: ${ADMIN_MANAGE_AUTH_TOKEN:-adminsecrettoken}
-      AUTHSERVER_NGROK_URL: ${AUTHSERVER_NGROK_URL:-https://authserver.share.zrok.io}
+      # Reuses the same public URL already configured for the auth-server
+      # service itself (TENANT_ISSUER_BASE_URL) — no separate zrok-specific
+      # variable needed.
+      AUTHSERVER_PUBLIC_URL: ${TENANT_ISSUER_BASE_URL:-https://authserver.share.zrok.io}
       TENANT_SECRET: tenantsecrettoken #Used by the issuer introspect tokens on auth server.
     depends_on:
       issuer:

--- a/oid4vc/demo/docker-compose-zrok.yaml
+++ b/oid4vc/demo/docker-compose-zrok.yaml
@@ -1,8 +1,10 @@
 services:
 
   issuer:
-    # from .. run
-    # DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build -f ./docker/Dockerfile --tag oid4vci .
+    # isomdl-uniffi ships prebuilt wheels only for linux/amd64 (see
+    # docker/Dockerfile) — force amd64 so it builds/runs correctly under
+    # emulation on arm64 hosts (e.g. Apple Silicon).
+    platform: linux/amd64
     image: oid4vc
     build:
       dockerfile: docker/Dockerfile
@@ -114,10 +116,15 @@ services:
       - ${HOME}/.zrok:/home/ziggy/.zrok
     environment:
       PFXLOG_NO_JSON: "true"
-      ZROK_TARGET: http://issuer:8082
+    # zrok has no ZROK_TARGET env var — the backend target is either
+    # whatever was persisted server-side by the original `zrok reserve`
+    # command, or whatever --override-endpoint passes here. Without the
+    # flag, "localhost" resolves inside *this* container's own network
+    # namespace, not the sibling `issuer` container, so it must be passed
+    # explicitly on every run.
     # Reserve the name once, then keep sharing it from this container.
     # Example: zrok reserve public --unique-name issuer http://localhost:8082
-    command: share reserved "${ISSUER_ZROK_NAME:-issuer}" --headless
+    command: share reserved "${ISSUER_ZROK_NAME:-issuer}" --override-endpoint http://issuer:8082 --headless
     depends_on:
       issuer:
         condition: service_healthy
@@ -130,9 +137,10 @@ services:
       - ${HOME}/.zrok:/home/ziggy/.zrok
     environment:
       PFXLOG_NO_JSON: "true"
-      ZROK_TARGET: http://auth-server:9001
+    # See the note on issuer-zrok above: --override-endpoint is required,
+    # there is no env var for this.
     # Example: zrok reserve public --unique-name authserver http://localhost:9001
-    command: share reserved "${AUTHSERVER_ZROK_NAME:-authserver}" --headless
+    command: share reserved "${AUTHSERVER_ZROK_NAME:-authserver}" --override-endpoint http://auth-server:9001 --headless
     depends_on:
       auth-server:
         condition: service_healthy
@@ -145,12 +153,39 @@ services:
       - ${HOME}/.zrok:/home/ziggy/.zrok
     environment:
       PFXLOG_NO_JSON: "true"
-      ZROK_TARGET: http://demo-app:3000
+    # See the note on issuer-zrok above: --override-endpoint is required,
+    # there is no env var for this.
     # Example: zrok reserve public --unique-name demo http://localhost:3000
-    command: share reserved "${DEMO_ZROK_NAME:-demo}" --headless
+    command: share reserved "${DEMO_ZROK_NAME:-demo}" --override-endpoint http://demo-app:3000 --headless
     depends_on:
       demo-app:
         condition: service_healthy
+
+  # zrok's agent can silently lose its OpenZiti circuit while still reporting
+  # the share as "active" (openziti/zrok#1259). Docker never sees a crash, so
+  # nothing restarts it on its own. This polls each share's public URL and
+  # restarts the container when it stops answering.
+  zrok-watchdog:
+    image: docker:27-cli
+    restart: unless-stopped
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./zrok-watchdog.sh:/zrok-watchdog.sh:ro,z
+    environment:
+      CHECK_INTERVAL: 30
+      CHECK_TIMEOUT: 10
+      ISSUER_PUBLIC_URL: ${OID4VCI_ENDPOINT:-https://issuer.share.zrok.io}
+      AUTHSERVER_PUBLIC_URL: ${TENANT_ISSUER_BASE_URL:-https://authserver.share.zrok.io}
+      DEMO_PUBLIC_URL: ${DEMO_PUBLIC_URL:-https://demo.share.zrok.io}
+    entrypoint: >
+      /bin/sh -c 'apk add --no-cache curl >/dev/null && exec /zrok-watchdog.sh'
+    depends_on:
+      issuer-zrok:
+        condition: service_started
+      authserver-zrok:
+        condition: service_started
+      demo-zrok:
+        condition: service_started
 
   demo-app:
     build:

--- a/oid4vc/demo/docker-compose-zrok.yaml
+++ b/oid4vc/demo/docker-compose-zrok.yaml
@@ -1,0 +1,235 @@
+services:
+
+  issuer:
+    # from .. run
+    # DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build -f ./docker/Dockerfile --tag oid4vci .
+    image: oid4vc
+    build:
+      dockerfile: docker/Dockerfile
+      context: ../
+    ports:
+      - "3000:3000"
+      - "3001:3001"
+      - "8082:8082"
+    volumes:
+      - ../docker/entrypoint.sh:/entrypoint.sh:ro,z
+    environment:
+      RUST_LOG: warn
+      # These default to stable zrok URLs so the app can run without ngrok.
+      OID4VCI_ENDPOINT: ${OID4VCI_ENDPOINT:-https://issuer.share.zrok.io}
+      STATUS_LIST_PUBLIC_URI: ${STATUS_LIST_PUBLIC_URI:-https://issuer.share.zrok.io/tenant/{tenant_id}/status/{list_number}}
+      OID4VCI_HOST: 0.0.0.0
+      OID4VCI_PORT: 8082
+      OID4VCI_STATUS_HANDLER: status_list.v1_0.status_handler
+      STATUS_LIST_SIZE: 131072
+      STATUS_LIST_SHARD_SIZE: 131072
+      #STATUS_LIST_PUBLIC_URI: https://localhost:8082/tenant/{tenant_id}/status/{list_number} Set in entrypoint.sh
+      STATUS_LIST_FILE_PATH: /tmp/bitstring/{tenant_id}/{list_number}
+    entrypoint: >
+      /bin/sh -c '/entrypoint.sh aca-py "$$@"' --
+    # Note: --no-transport should be added to start but currently blocks webhooks - fix in ACA-Py main.
+    # A nice feature would be to have common sets to --block-plugin.
+    command: >
+      start
+        --inbound-transport http 0.0.0.0 3000
+        --outbound-transport http
+        --endpoint http://issuer:3000
+        --admin 0.0.0.0 3001
+        --admin-insecure-mode
+        --webhook-url http://demo-app:3000/webhook
+        --webhook-url http://webhook-listener:8080
+        --no-ledger
+        --wallet-type askar
+        --emit-new-didcomm-prefix
+        --wallet-storage-type default
+        --wallet-name issuer
+        --wallet-key insecure
+        --auto-provision
+        --log-level DEBUG
+        --debug-webhooks
+        --plugin oid4vc
+        --plugin jwt_vc_json
+        --plugin sd_jwt_vc
+        --plugin mso_mdoc
+        --plugin status_list.v1_0
+        --multitenant
+        --multitenant-admin
+        --jwt-secret insecure
+        --log-level INFO
+        --multitenancy-config wallet_type=single-wallet-askar key_derivation_method=RAW
+        --block-plugin acapy_agent.anoncreds
+        --block-plugin acapy_agent.ledger
+        --block-plugin acapy_agent.revocation
+        --block-plugin acapy_agent.messaging.schemas
+        --block-plugin acapy_agent.messaging.credential_definitions
+        --block-plugin acapy_agent.revocation_anoncreds
+        --block-plugin acapy_agent.anoncreds.default.did_indy
+        --block-plugin acapy_agent.anoncreds.default.did_web
+        --block-plugin acapy_agent.anoncreds.default.legacy_indy
+        --block-plugin acapy_agent.vc
+        --block-plugin acapy_agent.vc.data_integrity
+        --block-plugin acapy_agent.messaging.jsonld
+        --block-plugin acapy_agent.anoncreds.revocation
+        --block-plugin acapy_agent.connections
+        --block-plugin acapy_agent.did.indy
+        --block-plugin acapy_agent.holder
+        --block-plugin acapy_agent.protocols.actionmenu
+        --block-plugin acapy_agent.protocols.basicmessage
+        --block-plugin acapy_agent.protocols.coordinate_mediation
+        --block-plugin acapy_agent.protocols.didexchange
+        --block-plugin acapy_agent.protocols.discovery
+        --block-plugin acapy_agent.protocols.endorse_transaction
+        --block-plugin acapy_agent.protocols.introduction
+        --block-plugin acapy_agent.protocols.issue_credential
+        --block-plugin acapy_agent.protocols.notification
+        --block-plugin acapy_agent.protocols.out_of_band
+        --block-plugin acapy_agent.protocols.present_proof
+        --block-plugin acapy_agent.protocols.problem_report
+        --block-plugin acapy_agent.protocols.revocation_notification
+        --block-plugin acapy_agent.protocols.routing
+        --block-plugin acapy_agent.protocols.trustping
+        --block-plugin acapy_agent.resolver
+    healthcheck:
+      test: curl -s -o /dev/null -w '%{http_code}' "http://localhost:3001/status/live" | grep "200" > /dev/null
+      start_period: 30s
+      interval: 7s
+      timeout: 5s
+      retries: 5
+    depends_on:
+      webhook-listener:
+        condition: service_started
+      auth-server:
+        condition: service_healthy
+
+  webhook-listener:
+    image: mendhak/http-https-echo:18
+    environment:
+      - HTTP_PORT=8080
+
+  issuer-zrok:
+    image: openziti/zrok
+    restart: unless-stopped
+    user: "${UID:-1000}:${GID:-1000}"
+    volumes:
+      - ${HOME}/.zrok:/home/ziggy/.zrok
+    environment:
+      PFXLOG_NO_JSON: "true"
+      ZROK_TARGET: http://issuer:8082
+    # Reserve the name once, then keep sharing it from this container.
+    # Example: zrok reserve public --unique-name issuer http://localhost:8082
+    command: share reserved "${ISSUER_ZROK_NAME:-issuer}" --headless
+    depends_on:
+      issuer:
+        condition: service_healthy
+
+  authserver-zrok:
+    image: openziti/zrok
+    restart: unless-stopped
+    user: "${UID:-1000}:${GID:-1000}"
+    volumes:
+      - ${HOME}/.zrok:/home/ziggy/.zrok
+    environment:
+      PFXLOG_NO_JSON: "true"
+      ZROK_TARGET: http://auth-server:9001
+    # Example: zrok reserve public --unique-name authserver http://localhost:9001
+    command: share reserved "${AUTHSERVER_ZROK_NAME:-authserver}" --headless
+    depends_on:
+      auth-server:
+        condition: service_healthy
+
+  demo-zrok:
+    image: openziti/zrok
+    restart: unless-stopped
+    user: "${UID:-1000}:${GID:-1000}"
+    volumes:
+      - ${HOME}/.zrok:/home/ziggy/.zrok
+    environment:
+      PFXLOG_NO_JSON: "true"
+      ZROK_TARGET: http://demo-app:3000
+    # Example: zrok reserve public --unique-name demo http://localhost:3000
+    command: share reserved "${DEMO_ZROK_NAME:-demo}" --headless
+    depends_on:
+      demo-app:
+        condition: service_healthy
+
+  demo-app:
+    build:
+      context: ./frontend
+    ports:
+      - "3002:3000"
+    volumes:
+      - ./frontend/index.js:/app/index.js:z
+      - ./frontend/templates:/app/templates:z
+    environment:
+      NODE_ENV: development # Set NODE_ENV to 'development'
+      WDS_SOCKET_PORT: 0
+      API_BASE_URL: http://issuer:3001
+      FORCE_COLOR: 3
+      ADMIN_MANAGE_AUTH_TOKEN: $ADMIN_MANAGE_AUTH_TOKEN
+      AUTHSERVER_NGROK_URL: ${AUTHSERVER_NGROK_URL:-https://authserver.share.zrok.io}
+      TENANT_SECRET: tenantsecrettoken #Used by the issuer introspect tokens on auth server.
+    depends_on:
+      issuer:
+        condition: service_healthy
+
+
+  #setup Auth Server. 
+  #ADMIN_MANAGE_AUTH_TOKEN is sourced from the .env as it is shared with demo-app.
+  #Other environment variables are set explicitly here to show a working configuration.
+  #Admin full list: https://github.com/openwallet-foundation/acapy-plugins/blob/main/oid4vc/auth_server/admin/config.py
+  #Tenant full list:https://github.com/openwallet-foundation/acapy-plugins/blob/main/oid4vc/auth_server/tenant/config.py
+  auth-server:
+    build:
+      dockerfile: docker/Dockerfile
+      context: ../auth_server
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - ./init.sql:/usr/src/app/alembic/sql/init.sql:ro
+    environment:
+      ADMIN_DB_HOST: db
+      ADMIN_DB_USER: auth_server_admin
+      ADMIN_DB_PASSWORD: postgres
+      ADMIN_DB_NAME: auth_server_admin
+      ADMIN_DB_PORT: 5432
+      ADMIN_DB_SCHEMA: admin
+      ADMIN_APP_TITLE: OAuth 2.0 Authorization Server Admin API
+      ADMIN_APP_VERSION: 0.2.0
+      ADMIN_APP_ROOT_PATH: /
+      ADMIN_MANAGE_AUTH_TOKEN: $ADMIN_MANAGE_AUTH_TOKEN # Access the admin API with this token
+      ADMIN_INTERNAL_AUTH_TOKEN: $ADMIN_INTERNAL_AUTH_TOKEN # Admin API request to admin API
+      ADMIN_TENANT_DB_NAME: auth_server_tenant
+      ADMIN_TENANT_DB_SCHEMA: auth
+      TENANT_INTERNAL_BASE_URL: http://auth-server:9000/internal
+      TENANT_INTERNAL_AUTH_TOKEN: $TENANT_INTERNAL_AUTH_TOKEN # match ADMIN_INTERNAL_AUTH_TOKEN
+      TENANT_APP_ROOT_PATH: /
+      TENANT_DB_HOST: db
+      TENANT_DB_PORT: 5432
+      TENANT_PROXY_TRUSTED_HOSTS: "*"
+      TENANT_ISSUER_BASE_URL: ${TENANT_ISSUER_BASE_URL:-https://authserver.share.zrok.io}
+    depends_on:
+      db:
+        condition: service_healthy
+    healthcheck:
+      test: >
+        curl -s -o /dev/null -w '%{http_code}' "http://localhost:9000/healthz" | grep "200" > /dev/null &&
+        curl -s -o /dev/null -w '%{http_code}' "http://localhost:9001/healthz" | grep "200" > /dev/null
+      start_period: 30s
+      interval: 7s
+      timeout: 5s
+      retries: 5
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_DB: postgres
+    ports:
+      - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+      start_period: 10s

--- a/oid4vc/demo/docker-compose-zrok.yaml
+++ b/oid4vc/demo/docker-compose-zrok.yaml
@@ -1,9 +1,13 @@
 services:
 
   issuer:
-    # isomdl-uniffi ships prebuilt wheels only for linux/amd64 (see
-    # docker/Dockerfile) — force amd64 so it builds/runs correctly under
-    # emulation on arm64 hosts (e.g. Apple Silicon).
+    # Building isomdl-uniffi from source requires zig as the linker
+    # (.cargo/config.toml routes aarch64/x86_64 Linux targets through
+    # `zig cc`), but zig's LLD-based linker doesn't support
+    # --fix-cortex-a53-843419, which rustc adds by default for
+    # aarch64-unknown-linux-gnu — this breaks native arm64 builds on
+    # Apple Silicon hosts (confirmed; unresolved upstream in zig/LLD).
+    # Force amd64 to route around it; runs under emulation on arm64 hosts.
     platform: linux/amd64
     image: oid4vc
     build:
@@ -57,7 +61,6 @@ services:
         --multitenant
         --multitenant-admin
         --jwt-secret insecure
-        --log-level INFO
         --multitenancy-config wallet_type=single-wallet-askar key_derivation_method=RAW
         --block-plugin acapy_agent.anoncreds
         --block-plugin acapy_agent.ledger

--- a/oid4vc/demo/docker-compose-zrok.yaml
+++ b/oid4vc/demo/docker-compose-zrok.yaml
@@ -165,12 +165,19 @@ services:
       WDS_SOCKET_PORT: 0
       API_BASE_URL: http://issuer:3001
       FORCE_COLOR: 3
-      ADMIN_MANAGE_AUTH_TOKEN: $ADMIN_MANAGE_AUTH_TOKEN
+      ADMIN_MANAGE_AUTH_TOKEN: ${ADMIN_MANAGE_AUTH_TOKEN:-adminsecrettoken}
       AUTHSERVER_NGROK_URL: ${AUTHSERVER_NGROK_URL:-https://authserver.share.zrok.io}
       TENANT_SECRET: tenantsecrettoken #Used by the issuer introspect tokens on auth server.
     depends_on:
       issuer:
         condition: service_healthy
+    healthcheck:
+      test:
+        ["CMD", "node", "-e", "fetch('http://127.0.0.1:3000/healthz').then(r => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"]
+      start_period: 30s
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
 
   #setup Auth Server. 
@@ -197,12 +204,12 @@ services:
       ADMIN_APP_TITLE: OAuth 2.0 Authorization Server Admin API
       ADMIN_APP_VERSION: 0.2.0
       ADMIN_APP_ROOT_PATH: /
-      ADMIN_MANAGE_AUTH_TOKEN: $ADMIN_MANAGE_AUTH_TOKEN # Access the admin API with this token
-      ADMIN_INTERNAL_AUTH_TOKEN: $ADMIN_INTERNAL_AUTH_TOKEN # Admin API request to admin API
+      ADMIN_MANAGE_AUTH_TOKEN: ${ADMIN_MANAGE_AUTH_TOKEN:-adminsecrettoken} # Access the admin API with this token
+      ADMIN_INTERNAL_AUTH_TOKEN: ${ADMIN_INTERNAL_AUTH_TOKEN:-admininternaltoken} # Admin API request to admin API
       ADMIN_TENANT_DB_NAME: auth_server_tenant
       ADMIN_TENANT_DB_SCHEMA: auth
       TENANT_INTERNAL_BASE_URL: http://auth-server:9000/internal
-      TENANT_INTERNAL_AUTH_TOKEN: $TENANT_INTERNAL_AUTH_TOKEN # match ADMIN_INTERNAL_AUTH_TOKEN
+      TENANT_INTERNAL_AUTH_TOKEN: ${TENANT_INTERNAL_AUTH_TOKEN:-admininternaltoken} # match ADMIN_INTERNAL_AUTH_TOKEN
       TENANT_APP_ROOT_PATH: /
       TENANT_DB_HOST: db
       TENANT_DB_PORT: 5432

--- a/oid4vc/demo/docker-compose.yaml
+++ b/oid4vc/demo/docker-compose.yaml
@@ -138,7 +138,9 @@ services:
       API_BASE_URL: http://issuer:3001
       FORCE_COLOR: 3
       ADMIN_MANAGE_AUTH_TOKEN: $ADMIN_MANAGE_AUTH_TOKEN
-      AUTHSERVER_NGROK_URL: $AUTHSERVER_NGROK_URL
+      # Container-facing name only — the host-side/.env variable stays
+      # AUTHSERVER_NGROK_URL so existing ngrok setups need no changes.
+      AUTHSERVER_PUBLIC_URL: $AUTHSERVER_NGROK_URL
       TENANT_SECRET: tenantsecrettoken #Used by the issuer introspect tokens on auth server.
     depends_on:
       issuer:

--- a/oid4vc/demo/docker-compose.yaml
+++ b/oid4vc/demo/docker-compose.yaml
@@ -3,8 +3,10 @@ version: '3'
 services:
 
   issuer:
-    # from .. run
-    # DOCKER_DEFAULT_PLATFORM=linux/amd64 docker build -f ./docker/Dockerfile --tag oid4vci .
+    # isomdl-uniffi ships prebuilt wheels only for linux/amd64 (see
+    # docker/Dockerfile) — force amd64 so it builds/runs correctly under
+    # emulation on arm64 hosts (e.g. Apple Silicon).
+    platform: linux/amd64
     image: oid4vc
     build:
       dockerfile: docker/Dockerfile

--- a/oid4vc/demo/docker-compose.yaml
+++ b/oid4vc/demo/docker-compose.yaml
@@ -3,9 +3,13 @@ version: '3'
 services:
 
   issuer:
-    # isomdl-uniffi ships prebuilt wheels only for linux/amd64 (see
-    # docker/Dockerfile) — force amd64 so it builds/runs correctly under
-    # emulation on arm64 hosts (e.g. Apple Silicon).
+    # Building isomdl-uniffi from source requires zig as the linker
+    # (.cargo/config.toml routes aarch64/x86_64 Linux targets through
+    # `zig cc`), but zig's LLD-based linker doesn't support
+    # --fix-cortex-a53-843419, which rustc adds by default for
+    # aarch64-unknown-linux-gnu — this breaks native arm64 builds on
+    # Apple Silicon hosts (confirmed; unresolved upstream in zig/LLD).
+    # Force amd64 to route around it; runs under emulation on arm64 hosts.
     platform: linux/amd64
     image: oid4vc
     build:
@@ -57,7 +61,6 @@ services:
         --multitenant
         --multitenant-admin
         --jwt-secret insecure
-        --log-level INFO
         --multitenancy-config wallet_type=single-wallet-askar key_derivation_method=RAW
         --block-plugin acapy_agent.anoncreds
         --block-plugin acapy_agent.ledger

--- a/oid4vc/demo/env.zrok.example
+++ b/oid4vc/demo/env.zrok.example
@@ -17,6 +17,8 @@ OID4VCI_ENDPOINT=https://issuer.share.zrok.io
 STATUS_LIST_PUBLIC_URI=https://issuer.share.zrok.io/tenant/{tenant_id}/status/{list_number}
 TENANT_ISSUER_BASE_URL=https://authserver.share.zrok.io
 AUTHSERVER_NGROK_URL=https://authserver.share.zrok.io
+# Used only by the zrok-watchdog service to poll the demo share's public URL.
+DEMO_PUBLIC_URL=https://demo.share.zrok.io
 
 # Optional if you want the zrok container(s) to bootstrap an enabled local environment.
 # ZROK_ENABLE_TOKEN=your-zrok-enable-token

--- a/oid4vc/demo/env.zrok.example
+++ b/oid4vc/demo/env.zrok.example
@@ -16,7 +16,6 @@ DEMO_ZROK_NAME=demo
 OID4VCI_ENDPOINT=https://issuer.share.zrok.io
 STATUS_LIST_PUBLIC_URI=https://issuer.share.zrok.io/tenant/{tenant_id}/status/{list_number}
 TENANT_ISSUER_BASE_URL=https://authserver.share.zrok.io
-AUTHSERVER_NGROK_URL=https://authserver.share.zrok.io
 # Used only by the zrok-watchdog service to poll the demo share's public URL.
 DEMO_PUBLIC_URL=https://demo.share.zrok.io
 

--- a/oid4vc/demo/env.zrok.example
+++ b/oid4vc/demo/env.zrok.example
@@ -1,0 +1,22 @@
+NGROK_AUTHTOKEN=your-ngrok-authtoken
+ADMIN_MANAGE_AUTH_TOKEN=adminsecrettoken
+ADMIN_INTERNAL_AUTH_TOKEN=admininternaltoken # match TENANT_INTERNAL_AUTH_TOKEN
+TENANT_INTERNAL_AUTH_TOKEN=admininternaltoken # match ADMIN_INTERNAL_AUTH_TOKEN
+
+# Reserve these zrok names once so the URLs stay stable between restarts.
+# zrok reserve public --unique-name issuer http://localhost:8082
+# zrok reserve public --unique-name authserver http://localhost:9001
+# zrok reserve public --unique-name demo http://localhost:3000
+
+TUNNEL_PROVIDER=zrok
+ISSUER_ZROK_NAME=issuer
+AUTHSERVER_ZROK_NAME=authserver
+DEMO_ZROK_NAME=demo
+
+OID4VCI_ENDPOINT=https://issuer.share.zrok.io
+STATUS_LIST_PUBLIC_URI=https://issuer.share.zrok.io/tenant/{tenant_id}/status/{list_number}
+TENANT_ISSUER_BASE_URL=https://authserver.share.zrok.io
+AUTHSERVER_NGROK_URL=https://authserver.share.zrok.io
+
+# Optional if you want the zrok container(s) to bootstrap an enabled local environment.
+# ZROK_ENABLE_TOKEN=your-zrok-enable-token

--- a/oid4vc/demo/frontend/entrypoint.sh
+++ b/oid4vc/demo/frontend/entrypoint.sh
@@ -3,9 +3,11 @@ set -e
 
 TUNNEL_ENDPOINT=${TUNNEL_ENDPOINT:-http://ngrok:4040}
 
-# Get the authserver tunnel public URL using jq
-AUTHSERVER_NGROK_URL=$(curl --silent "${TUNNEL_ENDPOINT}/api/tunnels" | jq -r '.tunnels[] | select(.name == "authserver") | .public_url')
-export AUTHSERVER_NGROK_URL
+if [[ -z "${AUTHSERVER_NGROK_URL:-}" ]]; then
+	# Get the authserver tunnel public URL using jq
+	AUTHSERVER_NGROK_URL=$(curl --silent "${TUNNEL_ENDPOINT}/api/tunnels" | jq -r '.tunnels[] | select(.name == "authserver") | .public_url')
+	export AUTHSERVER_NGROK_URL
+fi
 echo "AUTHSERVER_NGROK_URL: $AUTHSERVER_NGROK_URL"
 
 exec "$@"

--- a/oid4vc/demo/frontend/index.js
+++ b/oid4vc/demo/frontend/index.js
@@ -714,7 +714,10 @@ async function issue_mdoc_credential(req, res) {
 
   logger.info(mdocSupportedCredID);
   
-  // Create bitstring status list Configuration for mDoc (revocation)
+  // Create IETF Token Status List Configuration for mDoc (revocation).
+  // Must be "ietf", not "w3c" — check_status_list_claim() in
+  // mso_mdoc/mdoc/utils.py only recognizes the IETF status_list.{idx,uri}
+  // shape embedded by the status_list plugin for that list_type.
   const statusListCreateUrl = `${API_BASE_URL}/status-list/defs`;
   const statusListCreateOptions = {
     method: "POST",
@@ -722,7 +725,7 @@ async function issue_mdoc_credential(req, res) {
     body: JSON.stringify({
       issuer_did: issuerDID,
       list_size: 131072,
-      list_type: "w3c",
+      list_type: "ietf",
       shard_size: 131072,
       status_message: [
         {
@@ -1273,7 +1276,7 @@ function handleEvents(event_type, req, res) {
         if (state == "request-retrieved")
           res.write(`event: status\ndata: <div style="text-align: center;">QRCode Scanned, awaiting presentation...</div>\n\n`);
         if (state == "presentation-invalid")
-          res.write(`event: status\ndata: <div style="text-align: center;">Presentaion verification failed</div>\n\n`);
+          res.write(`event: status\ndata: <div style="text-align: center;">Presentation verification failed</div>\n\n`);
         if (state == "presentation-valid")
           res.write(`event: status\ndata: <div style="text-align: center;">Presentation Verified!</div>\n\n`);
       }
@@ -1602,13 +1605,32 @@ app.post("/update-status", async (req, res, next) => {
       headers: commonHeaders,
       body: JSON.stringify({ status: "1" })
     });
-    
+
     const respData = await response.text();
-    
+
     if (respData.includes("StatusListCred record not found")) {
       res.send(`<div class="w3-panel w3-pale-red w3-border"><p>${respData}</p></div>`);
     } else if (response.ok) {
-      res.send(`<div class="w3-panel w3-pale-green w3-border"><p>Status successfully updated for Credential Exchange ID: ${credId}</p></div>`);
+      // The PATCH above only flips the bit in the StatusListShard DB
+      // record. Verifiers fetch a separately-published snapshot, so the
+      // update is invisible until that snapshot is regenerated.
+      let publishWarning = "";
+      try {
+        const publishUrl = `${API_BASE_URL}/status-list/defs/${defId}/publish`;
+        const publishResponse = await fetch(publishUrl, {
+          method: "PUT",
+          headers: commonHeaders,
+        });
+        if (!publishResponse.ok) {
+          const publishError = await publishResponse.text();
+          logger.warn("Failed to publish status list:", publishError);
+          publishWarning = `<p>Warning: status updated but publish failed: ${publishError}</p>`;
+        }
+      } catch (err) {
+        logger.warn("Failed to publish status list:", err?.message || err);
+        publishWarning = `<p>Warning: status updated but publish failed: ${err?.message || err}</p>`;
+      }
+      res.send(`<div class="w3-panel w3-pale-green w3-border"><p>Status successfully updated for Credential Exchange ID: ${credId}</p>${publishWarning}</div>`);
     } else {
       res.status(response.status).send(`<div class="w3-panel w3-pale-red w3-border"><p>Failed to update status: ${respData}</p></div>`);
     }

--- a/oid4vc/demo/frontend/index.js
+++ b/oid4vc/demo/frontend/index.js
@@ -86,11 +86,13 @@ let sdJwtSupportedCredCreated = false;
 let mdocSupportedCredCreated = false;
 let sdJwtStatusListCreated = false;
 let jwtStatusListCreated = false;
+let mdocStatusListCreated = false;
 let jwtVcSupportedCredID = "";
 let sdJwtSupportedCredID = "";
 let mdocSupportedCredID = "";
 let jwtStatusListID = "";
 let sdJwtStatusListID = "";
+let mdocStatusListID = "";
 
 
 //    ###     ######     ###            ########  ##    ##
@@ -712,6 +714,42 @@ async function issue_mdoc_credential(req, res) {
 
   logger.info(mdocSupportedCredID);
   
+  // Create bitstring status list Configuration for mDoc (revocation)
+  const statusListCreateUrl = `${API_BASE_URL}/status-list/defs`;
+  const statusListCreateOptions = {
+    method: "POST",
+    headers: commonHeaders,
+    body: JSON.stringify({
+      issuer_did: issuerDID,
+      list_size: 131072,
+      list_type: "w3c",
+      shard_size: 131072,
+      status_message: [
+        {
+            status: "0x00",
+            message: "active"
+        },
+        {
+            status: "0x01",
+            message: "inactive"
+        },
+    ],
+    status_purpose: "revocation",
+    status_size: 1,
+    supported_cred_id: mdocSupportedCredID,
+    verification_method: issuerDID+"#0"
+    })
+  };
+
+  if (!mdocStatusListCreated){
+    events.emit(`issuance-${req.body.registrationId}`, {type: "message", message: `Posting Create Status List Request to: ${statusListCreateUrl}`});
+    events.emit(`issuance-${req.body.registrationId}`, {type: "debug-message", message: "Request options", data: statusListCreateOptions});
+    const statusListResponse = await fetchApiData(statusListCreateUrl, statusListCreateOptions);
+    mdocStatusListID = statusListResponse.id;
+    events.emit(`issuance-${req.body.registrationId}`, {type: "message", message: `Created Status List ID: ${mdocStatusListID}`});
+    mdocStatusListCreated = true;
+  };
+
   // Create credential exchange
   const exchangeCreateUrl = `${API_BASE_URL}/oid4vci/exchange/create`;
  
@@ -1136,10 +1174,13 @@ async function create_mdoc_presentation(req, res) {
     headers: commonHeaders,
     body: JSON.stringify({
       dcql_query_id: dcqlQueryId,
+      // Request the holder to produce an mso_mdoc presentation. Include
+      // additional common VP formats as fallbacks for wallets that may
+      // prefer JWT-based VPs.
       vp_formats: {
-        mso_mdoc: {
-          alg: ["ES256"]
-        }
+        mso_mdoc: { alg: ["ES256"] },
+        jwt_vp: { alg: ["ES256", "EdDSA"] },
+        jwt_vp_json: { alg: ["ES256", "EdDSA"] }
       },
     }),
   };
@@ -1536,6 +1577,8 @@ app.post("/update-status", async (req, res, next) => {
       defId = jwtStatusListID;
     } else if (credType === "sdjwt") {
       defId = sdJwtStatusListID;
+    } else if (credType === "mdoc") {
+      defId = mdocStatusListID;
     } else {
       return res.status(400).send("Invalid credential type for status update.");
     }

--- a/oid4vc/demo/frontend/index.js
+++ b/oid4vc/demo/frontend/index.js
@@ -72,7 +72,7 @@ const presentationCache = new NodeCache({ stdTTL: 300, checkperiod: 400 });
 
 const API_BASE_URL = process.env.API_BASE_URL || "http://localhost:3001";
 const API_KEY = process.env.API_KEY;
-const AUTHSERVER_NGROK_URL = process.env.AUTHSERVER_NGROK_URL;
+const AUTHSERVER_PUBLIC_URL = process.env.AUTHSERVER_PUBLIC_URL;
 const ADMIN_MANAGE_AUTH_TOKEN = process.env.ADMIN_MANAGE_AUTH_TOKEN;
 const TENANT_SECRET = process.env.TENANT_SECRET;
 
@@ -1434,7 +1434,7 @@ async function initializeIssuerMetadata() {
     const payload = {
       authorization_servers: [
         {
-          public_url: `${AUTHSERVER_NGROK_URL}/tenants/${WALLET_ID}`,
+          public_url: `${AUTHSERVER_PUBLIC_URL}/tenants/${WALLET_ID}`,
           private_url: `http://auth-server:9001/tenants/${WALLET_ID}`,
           auth_type: "client_secret_basic",
           client_credentials: {

--- a/oid4vc/demo/frontend/index.js
+++ b/oid4vc/demo/frontend/index.js
@@ -1283,6 +1283,10 @@ app.get("/", (req, res) => {
   res.render("index", {"registrationId": uuidv4()});
 });
 
+app.get("/healthz", (req, res) => {
+  res.status(200).send("ok");
+});
+
 const fetchApiData = async (url, options) => {
   const response = await fetch(url, options);
   return await response.json();

--- a/oid4vc/demo/frontend/templates/update-status-form.ejs
+++ b/oid4vc/demo/frontend/templates/update-status-form.ejs
@@ -22,6 +22,7 @@
         <option value="" disabled selected>Credential Type</option>
         <option value="jwt">JWT</option>
         <option value="sdjwt">SD-JWT</option>
+        <option value="mdoc">mDL (mso_mdoc)</option>
       </select>
     </div>
     <div id="fields">

--- a/oid4vc/demo/zrok-watchdog.sh
+++ b/oid4vc/demo/zrok-watchdog.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+# Watchdog for zrok reserved shares.
+#
+# zrok's agent can silently lose its underlying OpenZiti circuit while still
+# reporting the share as "active" (openziti/zrok#1259) — the container never
+# crashes, so Docker's own restart policy never kicks in, and requests start
+# failing with a 502 from the zrok edge with no local symptom to detect it.
+# This polls each share's PUBLIC url from outside the tunnel and restarts the
+# container the moment it stops answering, which forces the agent to
+# re-establish a fresh circuit.
+
+set -eu
+
+CHECK_INTERVAL="${CHECK_INTERVAL:-30}"
+TIMEOUT="${CHECK_TIMEOUT:-10}"
+
+check_and_restart() {
+  service="$1"
+  url="$2"
+  [ -z "$url" ] && return 0
+
+  code=$(curl -s -o /dev/null -w '%{http_code}' --max-time "$TIMEOUT" "$url" || echo 000)
+  if [ "$code" = "502" ] || [ "$code" = "000" ]; then
+    echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $service unreachable via $url (HTTP $code) - restarting"
+    # Compose prefixes actual container names with the project name
+    # (e.g. "demo-issuer-zrok-1"), so look the container up by its
+    # compose service label rather than assuming the bare service name.
+    container=$(docker ps -q --filter "label=com.docker.compose.service=$service")
+    if [ -z "$container" ]; then
+      echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $service: no running container found for restart"
+      return 0
+    fi
+    docker restart "$container" || echo "$(date -u +%Y-%m-%dT%H:%M:%SZ) $service restart failed"
+    # give the agent a moment to re-establish before the next check
+    sleep 20
+  fi
+}
+
+echo "zrok-watchdog: polling every ${CHECK_INTERVAL}s (timeout ${TIMEOUT}s)"
+
+while true; do
+  check_and_restart issuer-zrok "${ISSUER_PUBLIC_URL:-}"
+  check_and_restart authserver-zrok "${AUTHSERVER_PUBLIC_URL:-}"
+  check_and_restart demo-zrok "${DEMO_PUBLIC_URL:-}"
+  sleep "$CHECK_INTERVAL"
+done

--- a/oid4vc/docker/Dockerfile
+++ b/oid4vc/docker/Dockerfile
@@ -20,17 +20,16 @@ RUN mkdir jwt_vc_json && touch jwt_vc_json/__init__.py
 RUN mkdir sd_jwt_vc && touch sd_jwt_vc/__init__.py
 RUN mkdir mso_mdoc && touch mso_mdoc/__init__.py
 RUN mkdir status_list && touch status_list/__init__.py
-RUN mkdir mso_mdoc/isomdl
 COPY pyproject.toml poetry.lock README.md ./
 RUN poetry install --without dev --all-extras
 
-#build the isomdl library from indicio. Tempory solution until we have a wheel on pypi with linux arm support
-RUN apt-get update && apt-get install -y git build-essential && apt-get clean
-RUN git clone https://github.com/Indicio-tech/isomdl-uniffi.git
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-ENV PATH="/root/.cargo/bin:${PATH}"
-WORKDIR /usr/src/app/isomdl-uniffi/python
-RUN python build.py
+# isomdl-uniffi isn't on PyPI and can't be a poetry dependency (it requires
+# a Rust toolchain to build) — install the prebuilt wheel from its GitHub
+# release instead, matching README.md's documented dev-setup instructions.
+# This image is built for linux/amd64 (see the `platform:` pin in the
+# compose files), so the manylinux x86_64 wheel is always the right one.
+RUN /usr/src/app/.venv/bin/pip install --no-cache-dir \
+    https://github.com/Indicio-tech/isomdl-uniffi/releases/download/v0.1.0-indicio.1/isomdl_uniffi-0.1.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
 
 USER $user
 
@@ -46,10 +45,6 @@ COPY sd_jwt_vc/ sd_jwt_vc/
 COPY oid4vc/ oid4vc/
 ADD https://github.com/openwallet-foundation/acapy-plugins.git#main:status_list/status_list/ status_list/
 COPY docker/*.yml ./
-
-#Install the isomdl library built in the base stage. 
-COPY --from=base /usr/src/app/isomdl-uniffi/python/isomdl_uniffi /usr/src/app/mso_mdoc/isomdl
-ENV PYTHONPATH="/usr/src/app/mso_mdoc/isomdl:$PYTHONPATH"
 
 ENTRYPOINT ["/bin/bash", "-c", "aca-py \"$@\"", "--"]
 CMD ["start", "--arg-file", "default.yml"]

--- a/oid4vc/docker/Dockerfile
+++ b/oid4vc/docker/Dockerfile
@@ -1,3 +1,5 @@
+# syntax=docker/dockerfile:1
+
 FROM python:3.13-slim-bookworm AS base
 WORKDIR /usr/src/app
 
@@ -20,16 +22,41 @@ RUN mkdir jwt_vc_json && touch jwt_vc_json/__init__.py
 RUN mkdir sd_jwt_vc && touch sd_jwt_vc/__init__.py
 RUN mkdir mso_mdoc && touch mso_mdoc/__init__.py
 RUN mkdir status_list && touch status_list/__init__.py
+RUN mkdir mso_mdoc/isomdl
 COPY pyproject.toml poetry.lock README.md ./
 RUN poetry install --without dev --all-extras
 
 # isomdl-uniffi isn't on PyPI and can't be a poetry dependency (it requires
-# a Rust toolchain to build) — install the prebuilt wheel from its GitHub
-# release instead, matching README.md's documented dev-setup instructions.
-# This image is built for linux/amd64 (see the `platform:` pin in the
-# compose files), so the manylinux x86_64 wheel is always the right one.
-RUN /usr/src/app/.venv/bin/pip install --no-cache-dir \
-    https://github.com/Indicio-tech/isomdl-uniffi/releases/download/v0.1.0-indicio.1/isomdl_uniffi-0.1.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+# a Rust toolchain to build). Build from source against the
+# feat/mso-status-claim branch (adds MSO-level status-claim support for
+# revocable mdoc issuance, not yet in a released wheel).
+#
+# Fetched via ADD (not RUN git clone) so BuildKit checks the remote ref on
+# every build and only invalidates this layer when the branch's commit
+# actually changes — a plain `RUN git clone <fixed args>` caches on the
+# command text and would keep reusing a stale checkout after new commits
+# land on the branch, requiring a full --no-cache rebuild every time.
+RUN apt-get update && apt-get install -y git build-essential && apt-get clean
+ADD https://github.com/Indicio-tech/isomdl-uniffi.git#feat/mso-status-claim /usr/src/app/isomdl-uniffi
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# isomdl-uniffi's .cargo/config.toml routes both x86_64 and aarch64 Linux
+# targets through `zig cc` (see its mise.toml, which pins zig) even for
+# native builds; without `zig` on PATH the Rust link step fails with
+# "zig: not found".
+RUN pip install --no-cache-dir ziglang \
+    && printf '#!/bin/sh\nexec python3 -m ziglang "$@"\n' > /usr/local/bin/zig \
+    && chmod +x /usr/local/bin/zig
+
+WORKDIR /usr/src/app/isomdl-uniffi/python
+# Cache cargo's downloaded crate registry and this crate's compiled build
+# artifacts across builds, so an isomdl-uniffi source change (a new commit
+# on the branch above) only recompiles the crates that actually changed
+# instead of all ~250 dependencies from scratch every time.
+RUN --mount=type=cache,target=/root/.cargo/registry,id=cargo-registry \
+    --mount=type=cache,target=/usr/src/app/isomdl-uniffi/rust/target,id=isomdl-uniffi-target \
+    python build.py
 
 USER $user
 
@@ -45,6 +72,10 @@ COPY sd_jwt_vc/ sd_jwt_vc/
 COPY oid4vc/ oid4vc/
 ADD https://github.com/openwallet-foundation/acapy-plugins.git#main:status_list/status_list/ status_list/
 COPY docker/*.yml ./
+
+# Install the isomdl library built in the base stage.
+COPY --from=base /usr/src/app/isomdl-uniffi/python/isomdl_uniffi /usr/src/app/mso_mdoc/isomdl
+ENV PYTHONPATH="/usr/src/app/mso_mdoc/isomdl:$PYTHONPATH"
 
 ENTRYPOINT ["/bin/bash", "-c", "aca-py \"$@\"", "--"]
 CMD ["start", "--arg-file", "default.yml"]

--- a/oid4vc/docker/entrypoint.sh
+++ b/oid4vc/docker/entrypoint.sh
@@ -24,9 +24,13 @@ liveliness_check () {
 
 liveliness_check "${TUNNEL_ENDPOINT}"
 
-export OID4VCI_ENDPOINT=$(curl --silent "${TUNNEL_ENDPOINT}/api/tunnels" | jq -r '.tunnels[] | select(.name == "issuer") | .public_url')
+if [[ -z "${OID4VCI_ENDPOINT:-}" ]]; then
+        export OID4VCI_ENDPOINT=$(curl --silent "${TUNNEL_ENDPOINT}/api/tunnels" | jq -r '.tunnels[] | select(.name == "issuer") | .public_url')
+fi
 
-export STATUS_LIST_PUBLIC_URI=${OID4VCI_ENDPOINT}/tenant/{tenant_id}/status/{list_number}
+if [[ -z "${STATUS_LIST_PUBLIC_URI:-}" ]]; then
+        export STATUS_LIST_PUBLIC_URI=${OID4VCI_ENDPOINT}/tenant/{tenant_id}/status/{list_number}
+fi
 
 echo "STATUS_LIST_PUBLIC_URI: $STATUS_LIST_PUBLIC_URI"
 

--- a/oid4vc/docker/entrypoint.sh
+++ b/oid4vc/docker/entrypoint.sh
@@ -22,9 +22,12 @@ liveliness_check () {
         done
 }
 
-liveliness_check "${TUNNEL_ENDPOINT}"
-
+# Only probe the ngrok tunnel-inspection API when OID4VCI_ENDPOINT hasn't
+# already been provided. zrok and other manual setups set it directly via
+# env and have no ngrok container to query, so the check would otherwise
+# fail after WAIT_ATTEMPTS and abort startup.
 if [[ -z "${OID4VCI_ENDPOINT:-}" ]]; then
+        liveliness_check "${TUNNEL_ENDPOINT}"
         export OID4VCI_ENDPOINT=$(curl --silent "${TUNNEL_ENDPOINT}/api/tunnels" | jq -r '.tunnels[] | select(.name == "issuer") | .public_url')
 fi
 

--- a/oid4vc/mso_mdoc/cred_processor.py
+++ b/oid4vc/mso_mdoc/cred_processor.py
@@ -22,6 +22,7 @@ from oid4vc.models.exchange import OID4VCIExchangeRecord
 from oid4vc.models.presentation import OID4VPPresentation
 from oid4vc.models.supported_cred import SupportedCredential
 from oid4vc.pop_result import PopResult
+from oid4vc.status_handler import StatusHandler
 
 from .mdoc.issuer import MDL_MANDATORY_FIELDS, isomdl_mdoc_sign
 from .mdoc.cred_verifier import MsoMdocCredVerifier
@@ -99,7 +100,9 @@ class MsoMdocCredProcessor(Issuer, CredVerifier, PresVerifier):
         string names to integer identifiers per OID4VCI 1.0 / ISO 18013-5.
         """
         format_data = supported_cred.pop("format_data", None) or {}
-        supported_cred.pop("vc_additional_data", None)  # trust anchors etc. are internal
+        supported_cred.pop(
+            "vc_additional_data", None
+        )  # trust anchors etc. are internal
 
         doctype = format_data.get("doctype")
         claims = format_data.get("claims")
@@ -346,65 +349,26 @@ class MsoMdocCredProcessor(Issuer, CredVerifier, PresVerifier):
         self,
         context: AdminRequestContext,
         supported: SupportedCredential,
-        doctype: str,
+        ex_record: OID4VCIExchangeRecord,
     ) -> Optional[Dict[str, Any]]:
-        """Optionally assign a Token Status List entry for the credential.
+        """Optionally assign a status list entry for the credential.
 
-        If ``status_list_def_id`` and ``status_list_base_uri`` are set in the
-        ``SupportedCredential.vc_additional_data``, this method attempts to
-        assign an entry from the status_list plugin and returns the status
-        claim dict to embed in the payload.
+        Delegates to the configured ``OID4VCI_STATUS_HANDLER`` plugin, the
+        same mechanism ``jwt_vc_json`` and ``sd_jwt_vc`` use. The handler
+        resolves the public status URI from ``STATUS_LIST_PUBLIC_URI`` and
+        looks up the status list definition by ``supported_cred_id``, so no
+        additional wiring is needed on the ``SupportedCredential`` record.
 
-        Returns ``None`` if the status list plugin is not installed or not
-        configured for this credential type.
+        Returns ``None`` if no status handler is configured or no status
+        list definition exists for this supported credential.
         """
-        additional = supported.vc_additional_data or {}
-        definition_id = additional.get("status_list_def_id")
-        base_uri = (additional.get("status_list_base_uri") or "").rstrip("/")
-
-        if not definition_id or not base_uri:
+        status_handler = context.inject_or(StatusHandler)
+        if not status_handler:
             return None
 
-        try:
-            from status_list.status_list.v1_0 import (  # noqa: PLC0415
-                status_handler as _status_handler,
-            )
-        except ImportError:
-            LOGGER.debug(
-                "status_list plugin not installed; skipping revocation entry assignment"
-            )
-            return None
-
-        try:
-            entry = await _status_handler.assign_status_list_entry(context, definition_id)
-        except Exception as exc:
-            LOGGER.warning(
-                "Failed to assign status list entry for definition %s: %s",
-                definition_id,
-                exc,
-            )
-            return None
-
-        if entry is None:
-            LOGGER.warning(
-                "Status list entry assignment returned None for definition %s",
-                definition_id,
-            )
-            return None
-
-        list_number = entry.get("list_number", "")
-        list_index = entry.get("list_index", 0)
-        status_uri = f"{base_uri}/{list_number}"
-
-        LOGGER.info(
-            "Assigned status list entry: doctype=%s list_number=%s index=%d uri=%s",
-            doctype,
-            list_number,
-            list_index,
-            status_uri,
+        return await status_handler.assign_status_entries(
+            context, supported.supported_cred_id, ex_record.exchange_id
         )
-
-        return {"status_list": {"idx": list_index, "uri": status_uri}}
 
     async def issue(
         self,
@@ -449,7 +413,9 @@ class MsoMdocCredProcessor(Issuer, CredVerifier, PresVerifier):
             payload = prepare_mdoc_payload(ex_record.credential_subject, doctype)
 
             # Optionally assign a status list entry and embed the status claim
-            status_claim = await self._assign_status_entry(context, supported, doctype)
+            status_claim = await self._assign_status_entry(
+                context, supported, ex_record
+            )
             if status_claim:
                 payload["status"] = status_claim
 
@@ -533,7 +499,9 @@ class MsoMdocCredProcessor(Issuer, CredVerifier, PresVerifier):
             # Log full exception for debugging before raising a generic error
             LOGGER.exception("mso_mdoc issuance error: %s", ex)
             # Surface the underlying exception text in the CredProcessorError
-            raise CredProcessorError(f"Failed to issue mso_mdoc credential: {ex}") from ex
+            raise CredProcessorError(
+                f"Failed to issue mso_mdoc credential: {ex}"
+            ) from ex
 
         # issuer_signed_b64() already returns base64url without padding
         # (ISO 18013-5 §8.3 compliant) — exactly what OID4VCI 1.0 §7.3.1 requires.
@@ -549,7 +517,9 @@ class MsoMdocCredProcessor(Issuer, CredVerifier, PresVerifier):
     def _normalize_mdoc_result(self, result: Any) -> str:
         return normalize_mdoc_result(result)
 
-    def validate_credential_subject(self, supported: SupportedCredential, subject: dict):
+    def validate_credential_subject(
+        self, supported: SupportedCredential, subject: dict
+    ):
         """Validate the credential subject."""
         if not subject:
             raise CredProcessorError("Credential subject cannot be empty")

--- a/oid4vc/mso_mdoc/cred_processor.py
+++ b/oid4vc/mso_mdoc/cred_processor.py
@@ -364,11 +364,22 @@ class MsoMdocCredProcessor(Issuer, CredVerifier, PresVerifier):
         """
         status_handler = context.inject_or(StatusHandler)
         if not status_handler:
+            LOGGER.info(
+                "No StatusHandler configured (OID4VCI_STATUS_HANDLER unset?); "
+                "issuing mdoc without a status claim"
+            )
             return None
 
-        return await status_handler.assign_status_entries(
+        status_claim = await status_handler.assign_status_entries(
             context, supported.supported_cred_id, ex_record.exchange_id
         )
+        LOGGER.info(
+            "Status claim for supported_cred_id=%s exchange_id=%s: %s",
+            supported.supported_cred_id,
+            ex_record.exchange_id,
+            status_claim,
+        )
+        return status_claim
 
     async def issue(
         self,
@@ -412,12 +423,12 @@ class MsoMdocCredProcessor(Issuer, CredVerifier, PresVerifier):
             # Get payload
             payload = prepare_mdoc_payload(ex_record.credential_subject, doctype)
 
-            # Optionally assign a status list entry and embed the status claim
+            # Optionally assign a status list entry and embed the status claim.
+            # Passed to isomdl_mdoc_sign separately (rather than merged into
+            # payload) since it's an MSO-level field, not a namespace element.
             status_claim = await self._assign_status_entry(
                 context, supported, ex_record
             )
-            if status_claim:
-                payload["status"] = status_claim
 
             # Resolve signing key — check MdocSigningKeyRecord first, then
             # fall back to vc_additional_data and env vars
@@ -483,7 +494,12 @@ class MsoMdocCredProcessor(Issuer, CredVerifier, PresVerifier):
                 )
 
             mso_mdoc = isomdl_mdoc_sign(
-                signing_holder_key, headers, payload, certificate_pem, private_key_pem
+                signing_holder_key,
+                headers,
+                payload,
+                certificate_pem,
+                private_key_pem,
+                status=status_claim,
             )
 
             # Normalize mDoc result handling for robust string/bytes processing

--- a/oid4vc/mso_mdoc/mdoc/cred_verifier.py
+++ b/oid4vc/mso_mdoc/mdoc/cred_verifier.py
@@ -186,8 +186,13 @@ class MsoMdocCredVerifier(CredVerifier):
                 if verification_result.verified:
                     claims = _extract_mdoc_claims(mdoc)
 
-                    # Check IETF Token Status List revocation if embedded in claims
-                    revocation_error = await check_status_list_claim(claims)
+                    # Check IETF Token Status List revocation from the MSO
+                    # status claim (not a namespace-embedded claim — read via
+                    # Mdoc.status()).
+                    status_json = mdoc.status_list()
+                    status_claim = json.loads(status_json) if status_json else None
+                    LOGGER.info("mdoc.status_list() for verification: %s", status_json)
+                    revocation_error = await check_status_list_claim(status_claim)
                     if revocation_error:
                         LOGGER.warning(
                             "mDoc credential rejected — credential revoked: %s",

--- a/oid4vc/mso_mdoc/mdoc/issuer.py
+++ b/oid4vc/mso_mdoc/mdoc/issuer.py
@@ -118,6 +118,7 @@ def isomdl_mdoc_sign(
     payload: Mapping[str, Any],
     iaca_cert_pem: str,
     iaca_key_pem: str,
+    status: Optional[dict] = None,
 ) -> str:
     """Create a signed mso_mdoc using isomdl-uniffi.
 
@@ -137,6 +138,9 @@ def isomdl_mdoc_sign(
         payload: The credential data to sign
         iaca_cert_pem: Issuer certificate in PEM format
         iaca_key_pem: Issuer private key in PEM format
+        status: Optional status claim (e.g. an IETF status-list
+            `{"status_list": {"idx": ..., "uri": ...}}` object) to embed in
+            the MSO for revocation checking.
 
     Returns:
         CBOR-encoded mDoc as string
@@ -167,6 +171,8 @@ def isomdl_mdoc_sign(
                 len(signing_cert_pem),
             )
 
+        status_json = json.dumps(status) if status else None
+
         # Prepare namespaces based on doctype
         if doctype == "org.iso.18013.5.1.mDL":
             # Use the dedicated mDL constructor — accepts JSON strings and
@@ -179,6 +185,7 @@ def isomdl_mdoc_sign(
                 holder_jwk,
                 signing_cert_pem,
                 iaca_key_pem,
+                status_json,
             )
         else:
             namespaces = _prepare_generic_namespaces(doctype, payload)
@@ -189,6 +196,7 @@ def isomdl_mdoc_sign(
                 holder_jwk,
                 signing_cert_pem,
                 iaca_key_pem,
+                status_json,
             )
 
         LOGGER.info("Generated mdoc with doctype: %s", mdoc.doctype())

--- a/oid4vc/mso_mdoc/mdoc/pres_verifier.py
+++ b/oid4vc/mso_mdoc/mdoc/pres_verifier.py
@@ -287,8 +287,16 @@ class MsoMdocPresVerifier(PresVerifier):
                         LOGGER.warning("Failed to extract claims: %s", e)
                         claims = {}
 
-                    # Check IETF Token Status List revocation if embedded in claims
-                    revocation_error = await check_status_list_claim(claims)
+                    # Check IETF Token Status List revocation from the MSO
+                    # status claim (not a namespace-embedded claim — read via
+                    # the reader-side status_list field on the verified response).
+                    status_json = getattr(verified_data, "status_list", None)
+                    status_claim = json.loads(status_json) if status_json else None
+                    LOGGER.info(
+                        "verified_data.status_list for presentation verification: %s",
+                        status_json,
+                    )
+                    revocation_error = await check_status_list_claim(status_claim)
                     if revocation_error:
                         LOGGER.warning(
                             "mDoc presentation rejected — credential revoked: %s",

--- a/oid4vc/mso_mdoc/mdoc/utils.py
+++ b/oid4vc/mso_mdoc/mdoc/utils.py
@@ -25,10 +25,10 @@ def split_pem_chain(pem_chain: str) -> List[str]:
     When a caller stores or passes a multi-cert chain as one string, every cert
     after the first is silently dropped, causing either:
 
-    * **Issuer side** – the wrong certificate is embedded in the MSO (the
+    * **Issuer side** - the wrong certificate is embedded in the MSO (the
       signing key no longer corresponds to the embedded cert → verification
       fails).
-    * **Verifier side** – trust-anchor chains are truncated to one cert, so
+    * **Verifier side** - trust-anchor chains are truncated to one cert, so
       any mdoc whose embedded cert is not the single root in the chain cannot
       be verified.
 
@@ -105,13 +105,17 @@ def flatten_trust_anchors(trust_anchors: List[str]) -> List[str]:
     return flat
 
 
-async def check_status_list_claim(claims: dict) -> Optional[str]:
-    """Check IETF Token Status List revocation status embedded in mDoc claims.
+async def check_status_list_claim(status_claim: Optional[dict]) -> Optional[str]:
+    """Check IETF Token Status List revocation status from an MSO status claim.
 
-    Searches all namespaces in *claims* for a ``status.status_list`` entry
-    containing ``idx`` (credential index) and ``uri`` (status list endpoint).
-    If found, fetches the published status list JWT, decodes the little-endian
-    compressed bitstring, and checks the bit(s) at *idx*.
+    *status_claim* is the credential's MSO-level status claim (e.g.
+    ``{"status_list": {"idx": ..., "uri": ...}}``), read back via
+    ``Mdoc.status()`` for direct credential verification or the reader-side
+    ``status`` field for OID4VP presentation verification — not discovered
+    by searching namespace claims; status isn't a namespace-embedded data
+    element, it lives on the MSO itself. If present, fetches the published
+    status list JWT, decodes the little-endian compressed bitstring, and
+    checks the bit(s) at ``idx``.
 
     Per IETF Token Status List draft:
     - ``status_list.lst``: base64url-encoded, zlib-compressed little-endian bitstring
@@ -119,35 +123,26 @@ async def check_status_list_claim(claims: dict) -> Optional[str]:
     - A non-zero value at position *idx* means the credential is revoked/suspended.
 
     Args:
-        claims: Namespace-keyed claims dict from ``extract_verified_claims`` or
-                ``_extract_mdoc_claims``, e.g.
-                ``{"org.iso.18013.5.1": {"family_name": "Smith", "status": {...}}}``
+        status_claim: The MSO's status claim dict, or ``None``/empty if the
+            credential has no status claim at all.
 
     Returns:
         ``None`` if the credential is valid (or has no status claim).
-        An error string if the credential is revoked or suspended.
+        An error string if the credential is revoked/suspended, or if its
+        status could not be determined (fetch/decode failure, malformed
+        claim, out-of-range index) — this fails closed rather than treating
+        an inconclusive check as "valid".
     """
-    # Search all namespaces for a status.status_list.{idx, uri} entry
-    status_entry = None
-    for ns_claims in claims.values():
-        if not isinstance(ns_claims, dict):
-            continue
-        status = ns_claims.get("status")
-        if isinstance(status, dict) and "status_list" in status:
-            status_entry = status["status_list"]
-            break
-
-    if not status_entry:
+    if not isinstance(status_claim, dict) or "status_list" not in status_claim:
         return None  # No revocable status claim → credential is valid
 
+    status_entry = status_claim["status_list"]
     idx = status_entry.get("idx")
     uri = status_entry.get("uri")
 
     if idx is None or not uri:
-        LOGGER.warning(
-            "Malformed status_list claim — missing idx or uri; skipping revocation check"
-        )
-        return None
+        LOGGER.warning("Malformed status_list claim — missing idx or uri")
+        return "Could not verify credential status: malformed status_list claim (missing idx or uri)"
 
     # Fetch the published status list JWT
     try:
@@ -158,12 +153,8 @@ async def check_status_list_claim(claims: dict) -> Optional[str]:
                 resp.raise_for_status()
                 jwt_text = await resp.text()
     except Exception as exc:
-        LOGGER.warning(
-            "Could not fetch status list from %r — revocation check skipped: %s",
-            uri,
-            exc,
-        )
-        return None  # Fail-open on network errors
+        LOGGER.warning("Could not fetch status list from %r: %s", uri, exc)
+        return f"Could not verify credential status: {exc}"
 
     # Decode JWT payload without signature verification
     try:
@@ -174,12 +165,12 @@ async def check_status_list_claim(claims: dict) -> Optional[str]:
         jwt_payload = _json.loads(base64.urlsafe_b64decode(payload_b64))
     except Exception as exc:
         LOGGER.warning("Failed to decode status list JWT from %r: %s", uri, exc)
-        return None
+        return f"Could not verify credential status: failed to decode status list JWT: {exc}"
 
     sl = jwt_payload.get("status_list")
     if not isinstance(sl, dict):
         LOGGER.warning("JWT from %r has no 'status_list' claim", uri)
-        return None
+        return "Could not verify credential status: status list JWT has no 'status_list' claim"
 
     bits: int = int(sl.get("bits", 1))
     lst: str = sl.get("lst", "")
@@ -190,7 +181,7 @@ async def check_status_list_claim(claims: dict) -> Optional[str]:
         raw_bytes = zlib.decompress(compressed)
     except Exception as exc:
         LOGGER.warning("Failed to decode status list bitstring from %r: %s", uri, exc)
-        return None
+        return f"Could not verify credential status: failed to decode status list bitstring: {exc}"
 
     # Extract the status value for credential at position *idx*.
     # IETF Token Status List uses little-endian bit ordering within each byte:
@@ -202,12 +193,14 @@ async def check_status_list_claim(claims: dict) -> Optional[str]:
 
     if byte_idx >= len(raw_bytes):
         LOGGER.warning(
-            "Status list index %d is out of range (list byte length=%d); "
-            "skipping revocation check",
+            "Status list index %d is out of range (list byte length=%d)",
             idx,
             len(raw_bytes),
         )
-        return None
+        return (
+            f"Could not verify credential status: index {idx} out of range "
+            f"for status list of length {len(raw_bytes)} bytes"
+        )
 
     mask = (1 << bits) - 1
     status_value = (raw_bytes[byte_idx] >> bit_in_byte) & mask


### PR DESCRIPTION
# Summary

Adds mDL/mdoc revocation support end-to-end — issuance with an embedded IETF status-list claim, status-list publishing/updates from the demo UI, and presentation-time status checking, and adds [zrok](https://zrok.io/) as an alternative tunnel provider for the OID4VC demo (alongside the existing ngrok setup)

## What's included

**mDL/mdoc revocation**
- `isomdl_mdoc_sign` (`mdoc/issuer.py`) now accepts an optional `status` claim, embedded into the MSO at issuance time.
- `mdoc/utils.py` adds status-list resolution/decoding: fetches the published IETF status-list JWT, decodes the bitstring, and returns the credential's current status (or a fail-closed error string if the check can't be completed).
- `mdoc/cred_verifier.py` / `mdoc/pres_verifier.py` wire status checking into presentation verification.
- Demo frontend creates an IETF-type status list for mdoc credentials at issuance and can revoke/re-publish through the existing "update status" UI.

**zrok demo support**
- New `docker-compose-zrok.yaml` + `env.zrok.example` — a zrok-based alternative to the ngrok demo stack, for environments where ngrok isn't viable (e.g. requires a paid plan for stable URLs).
- `zrok-watchdog.sh` polls the demo's public URL and restarts the share if it drops.
- `docker/entrypoint.sh`, `auth_server/docker/entrypoint.sh`, and `frontend/entrypoint.sh` now skip ngrok tunnel-introspection when the relevant URL env vars (`OID4VCI_ENDPOINT`, `TENANT_ISSUER_BASE_URL`, etc.) are already set directly — existing ngrok setups are unaffected.
- Renamed `AUTHSERVER_NGROK_URL` → `AUTHSERVER_PUBLIC_URL` internally (container-facing only); `docker-compose.yaml` maps the existing host-side `AUTHSERVER_NGROK_URL` var to it, so no `.env` changes are needed for existing ngrok users.

## Docker build — heads up for reviewers

This branch intentionally diverges from `main`'s current `oid4vc/docker/Dockerfile`, which installs a prebuilt `isomdl-uniffi` wheel (`v0.1.0-indicio.1`). That wheel does **not** have status-claim support, which the revocation feature above depends on. This PR instead builds `isomdl-uniffi` from source against the `Indicio-tech/isomdl-uniffi#feat/mso-status-claim` branch. This does result in slow build times and dependency on a mutable GitHub URL, rather than a stable release artifact. PRs are open in [`spruceid/isomdl`](https://github.com/spruceid/isomdl/pull/140) and [`Indicio-tech/isomdl_uniffi`](https://github.com/Indicio-tech/isomdl-uniffi/pull/33) to add status-claim support in the upstream dependencies.

Once `isomdl-uniffi` cuts an official release wheel with status-claim support, this Dockerfile should revert to the wheel-install pattern `main` currently uses (which I plan on taking care of before merging this PR, assuming those PRs get merged quickly enough). Left a `NOTE` comment in the Dockerfile itself as a pointer for whoever does that, if I don't have a chance to.

Separately, `.github/workflows/pr-linting-and-unit-tests.yaml` still installs the old `v0.1.0-indicio.1` wheel for unit tests (unchanged by this PR) — fine today since no unit test exercises the new `status` parameter directly, but worth knowing if that changes.

## Testing

- `ruff check .` and `ruff format --check .` pass.
- `poetry run pytest` — 45 passed.
- Manually exercised the zrok demo flow (issuance, presentation, status update/revocation) end-to-end.

## Requests for Feedback
General feedback for the PR as a whole is appreciated, but here are some specific items that I'd appreciate feedback on:
- Preexisting `ngrok` demo setup
  - Recent changes to ngrok require a paid account for multiple tunnels, which the demo uses. The ngrok setup _should_ be unchanged, but confirmation from someone with the ability to test that would be appreciated
- Confirmation of `zrok` demo instructions
  - I've done my best to make sure the instructions are accurate, but since these are my changes and my setup, it's possible I made some changes that didn't land in the documentation
- Confirmation of mDL Revocation
  - The core feature of this PR is adding mDL revocation support, so a thorough review there, and confirmation that it works on someone else's machine, would be great