### PR TITLE
Improves ACA-Py release test script adding support for LTS releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,9 +212,25 @@ Or against a subset of plugins:
 ./test_acapy_version.py 1.7.0rc0 basicmessage_storage webvh
 ```
 
+To test an LTS release, use `--tag` with the closest prior tag for that line
+(so the plugin set and code match what actually shipped there) instead of
+testing against the current checkout:
+
+```
+./test_acapy_version.py 1.3.6rc0 --tag 1.3.2
+```
+
 The script requires `poetry` and `docker` (with the `compose` plugin) and
 should be run from the repo root. It prints a pass/fail/skip summary for each
-plugin when it finishes.
+plugin when it finishes; full output for any failure (poetry lock, docker
+build, or integration test) is written to `.test-acapy-version.log` in the
+repo root instead of the terminal.
+
+Note: the script has some built-in handling for `poetry lock` failures on
+older `--tag` runs (relaxing native binding pins like `aries-askar` that may
+be stale relative to the target acapy-agent version). See
+`relax_native_binding_pins` in the script if a lock failure needs digging
+into.
 
 ## Deploy
 

--- a/test_acapy_version.py
+++ b/test_acapy_version.py
@@ -7,22 +7,37 @@ The script pins each plugin's acapy-agent dependency to the specified version,
 runs the integration tests, and then reverts any changes made to
 pyproject.toml and poetry.lock files.
 
-Usage: ./test_acapy_version.py <acapy-agent-version> [plugin ...]
+Usage: ./test_acapy_version.py <acapy-agent-version> [plugin ...] [--tag REF]
 
 Examples: ./test_acapy_version.py 1.7.0rc0
           ./test_acapy_version.py 1.7.0rc0 basicmessage_storage webvh
+          ./test_acapy_version.py 1.3.6rc0 --tag 1.3.2.1
+
+--tag checks out the given git tag/ref (e.g. the most recent tag for an
+ACA-Py LTS line) into a temporary worktree and runs the test there instead
+of against the current checkout, so the plugin set and code match what
+actually shipped on that line. The current working tree is left untouched.
 
 Requires: poetry, docker (with compose plugin). Run from the repo root.
 """
 
 import argparse
+import datetime
 import os
 import re
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent
+
+# Full output for anything that fails is appended here instead of printed, so
+# stdout stays limited to progress/status lines. Gitignored via the repo's
+# blanket `*.log` rule. Lives in REPO_ROOT (not a --tag worktree) so it
+# survives after the temporary worktree is removed.
+RUN_LOG_PATH = REPO_ROOT / ".test-acapy-version.log"
 
 # Matches pr-integration-tests.yaml, which skips cheqd's integration tests.
 SKIP_TESTS = {"cheqd"}
@@ -34,14 +49,27 @@ EXCLUDED_PLUGINS = {"plugin_globals"}
 
 ACAPY_DEP_RE = re.compile(r'(acapy-agent\s*=\s*\{\s*version\s*=\s*")[^"]+(")')
 
+# Native bindings that acapy-agent owns transitively (crypto/wallet/indy
+# libraries). Plugins pin these tightly in their integration dev-dependency
+# group to match whatever acapy-agent needed when the pin was last touched;
+# an older tag's pins can be stale for a newer acapy-agent version within the
+# same line, causing spurious `poetry lock` conflicts unrelated to the plugin
+# itself.
+NATIVE_BINDING_DEPS = ("anoncreds", "aries-askar", "indy-credx", "indy-vdr", "python3-indy")
 
-def discover_plugins() -> list[str]:
+NATIVE_BINDING_DEP_RE = re.compile(
+    r'(' + "|".join(re.escape(dep) for dep in NATIVE_BINDING_DEPS) + r')'
+    r'(\s*=\s*\{\s*version\s*=\s*")[~^]?([^"]+)(")'
+)
+
+
+def discover_plugins(root: Path) -> list[str]:
     """A plugin is any top-level directory whose pyproject.toml declares an
     acapy-agent dependency. Derived instead of hardcoded so new plugins are
     picked up automatically.
     """
     plugins = []
-    for pyproject in sorted(REPO_ROOT.glob("*/pyproject.toml")):
+    for pyproject in sorted(root.glob("*/pyproject.toml")):
         plugin = pyproject.parent.name
         if plugin in EXCLUDED_PLUGINS:
             continue
@@ -50,10 +78,10 @@ def discover_plugins() -> list[str]:
     return plugins
 
 
-def check_clean() -> None:
+def check_clean(root: Path) -> None:
     result = subprocess.run(
         ["git", "status", "--porcelain", "--", "*/pyproject.toml", "*/poetry.lock"],
-        cwd=REPO_ROOT,
+        cwd=root,
         capture_output=True,
         text=True,
     )
@@ -67,14 +95,64 @@ def check_clean() -> None:
         sys.exit(1)
 
 
-def revert(touched_files: list[str]) -> None:
+def revert(touched_files: list[str], root: Path) -> None:
     print()
     print("== Reverting version bump changes ==")
     if touched_files:
-        subprocess.run(["git", "checkout", "--", *touched_files], cwd=REPO_ROOT)
+        subprocess.run(["git", "checkout", "--", *touched_files], cwd=root)
         print("Reverted:", " ".join(touched_files))
     else:
         print("(nothing to revert)")
+
+
+def create_worktree(tag: str) -> Path:
+    """Check out `tag` into a temporary git worktree and return its path, so
+    the test can run against that tag's actual plugin set and source instead
+    of the current checkout (old tags predate this script and don't have a
+    fixed plugin list, so its own tree can't just be checked out in place).
+    """
+    tmp_dir = Path(tempfile.mkdtemp(prefix="test-acapy-version-"))
+    worktree_path = tmp_dir / "worktree"
+    print(f"== Checking out '{tag}' into temporary worktree {worktree_path} ==")
+    result = subprocess.run(
+        ["git", "worktree", "add", "--detach", str(worktree_path), tag],
+        cwd=REPO_ROOT,
+    )
+    if result.returncode != 0:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        print(f"error: failed to check out '{tag}'", file=sys.stderr)
+        sys.exit(1)
+    return worktree_path
+
+
+def reclaim_ownership(path: Path) -> None:
+    """Integration test containers run as root and can leave files in the
+    worktree (e.g. poetry/build artifacts) owned by root, which then blocks
+    cleanup as the invoking user. Use a throwaway container to chown
+    everything back before removing it.
+    """
+    subprocess.run(
+        [
+            "docker", "run", "--rm",
+            "-v", f"{path}:/wt",
+            "alpine",
+            "chown", "-R", f"{os.getuid()}:{os.getgid()}", "/wt",
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def remove_worktree(worktree_path: Path) -> None:
+    print()
+    print(f"== Removing temporary worktree {worktree_path} ==")
+    reclaim_ownership(worktree_path)
+    subprocess.run(
+        ["git", "worktree", "remove", "--force", str(worktree_path)],
+        cwd=REPO_ROOT,
+    )
+    subprocess.run(["git", "worktree", "prune"], cwd=REPO_ROOT)
+    shutil.rmtree(worktree_path.parent, ignore_errors=True)
 
 
 def set_version(pyproject_path: Path, version: str) -> bool:
@@ -88,6 +166,21 @@ def set_version(pyproject_path: Path, version: str) -> bool:
         return False
     pyproject_path.write_text(new_text)
     return True
+
+
+def relax_native_binding_pins(pyproject_path: Path) -> None:
+    """Loosen exact/tilde/caret pins on acapy-agent's own native-binding
+    deps (see NATIVE_BINDING_DEPS) to a lower-bound-only constraint, so
+    `poetry lock` can pick whatever version the target acapy-agent release
+    actually needs instead of being stuck on whatever was pinned when this
+    pyproject.toml was last touched. Only called for --tag runs: on the
+    current checkout these pins are already kept current, so relaxing them
+    there would just let poetry drift to untested binding versions.
+    """
+    text = pyproject_path.read_text()
+    new_text = NATIVE_BINDING_DEP_RE.sub(r"\1\2>=\3\4", text)
+    if new_text != text:
+        pyproject_path.write_text(new_text)
 
 
 _ENV_SNAPSHOT_SENTINEL = "___TEST_ACAPY_VERSION_ENV_SNAPSHOT___"
@@ -105,9 +198,12 @@ def env_from_sourced_script(script: Path) -> dict[str, str]:
         text=True,
     )
     script_output, _, env_dump = result.stdout.partition(_ENV_SNAPSHOT_SENTINEL + "\n")
-    print(script_output, end="")
     if result.returncode != 0:
-        print(result.stderr, file=sys.stderr)
+        log_failure(f"{script.name} output", text=script_output + result.stderr)
+        print(
+            f"[{now()}] warning: {script.name} failed, continuing with unmodified "
+            f"environment -- details in {RUN_LOG_PATH.name}"
+        )
         return dict(os.environ)
 
     env = dict(os.environ)
@@ -118,8 +214,36 @@ def env_from_sourced_script(script: Path) -> dict[str, str]:
     return env
 
 
-def run(cmd: list[str], cwd: Path, env: dict[str, str] | None = None) -> int:
-    return subprocess.run(cmd, cwd=cwd, env=env).returncode
+def now() -> str:
+    return datetime.datetime.now().strftime("%H:%M:%S")
+
+
+def run_logged(
+    cmd: list[str],
+    cwd: Path,
+    log_path: Path,
+    env: dict[str, str] | None = None,
+    mode: str = "w",
+) -> int:
+    """Run cmd with stdout/stderr redirected to log_path instead of the
+    console, so a passing run (the common case) doesn't flood the terminal.
+    """
+    with open(log_path, mode) as log_file:
+        result = subprocess.run(cmd, cwd=cwd, env=env, stdout=log_file, stderr=subprocess.STDOUT)
+    return result.returncode
+
+
+def log_failure(label: str, log_path: Path | None = None, text: str | None = None) -> None:
+    """Append full output to RUN_LOG_PATH instead of printing it, so stdout
+    stays limited to progress/status lines.
+    """
+    content = text if text is not None else (log_path.read_text() if log_path and log_path.exists() else "")
+    with open(RUN_LOG_PATH, "a") as f:
+        f.write(f"---- {label} ----\n")
+        f.write(content)
+        if content and not content.endswith("\n"):
+            f.write("\n")
+        f.write(f"---- end {label} ----\n\n")
 
 
 def compose_down(integration_dir: Path) -> None:
@@ -130,36 +254,63 @@ def compose_down(integration_dir: Path) -> None:
     )
 
 
-def test_plugin(plugin: str, version: str, touched_files: list[str]) -> str:
-    print()
-    print(f"== [{plugin}] pinning acapy-agent == {version} ==")
-    plugin_dir = REPO_ROOT / plugin
+def remove_standalone_network(name: str) -> None:
+    """Remove a docker network created outside of any compose project (e.g. by
+    init-network.sh), which `compose_down` won't touch. Best-effort: a later
+    plugin's leftover network shouldn't fail the whole run.
+    """
+    subprocess.run(
+        ["docker", "network", "rm", name],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+def test_plugin(
+    plugin: str,
+    version: str,
+    touched_files: list[str],
+    root: Path,
+    log_dir: Path,
+    relax_bindings: bool,
+) -> str:
+    print(f"[{now()}] [{plugin}] starting (acapy-agent {version})")
+    plugin_dir = root / plugin
     pyproject = plugin_dir / "pyproject.toml"
     lock = plugin_dir / "poetry.lock"
 
     if not pyproject.exists():
-        print(f"skip: {pyproject} not found")
+        print(f"[{now()}] [{plugin}] skip: no pyproject.toml")
         return "no-pyproject"
 
     if not set_version(pyproject, version):
+        print(f"[{now()}] [{plugin}] skip: no acapy-agent dependency")
         return "no-acapy-dep"
-    touched_files.append(str(pyproject.relative_to(REPO_ROOT)))
+    if relax_bindings:
+        relax_native_binding_pins(pyproject)
+    touched_files.append(str(pyproject.relative_to(root)))
 
-    print(f"== [{plugin}] regenerating poetry.lock ==")
-    if run(["poetry", "lock"], cwd=plugin_dir) != 0:
-        print(f"FAIL: [{plugin}] poetry lock failed (version {version} likely unresolvable)")
+    lock_log = log_dir / f"{plugin}-lock.log"
+    if run_logged(["poetry", "lock"], cwd=plugin_dir, log_path=lock_log) != 0:
+        log_failure(f"{plugin} poetry lock output", log_path=lock_log)
+        print(
+            f"[{now()}] [{plugin}] FAILED: poetry lock (version {version} likely "
+            f"unresolvable) -- details in {RUN_LOG_PATH.name}"
+        )
+        lock_log.unlink(missing_ok=True)
         if lock.exists():
-            touched_files.append(str(lock.relative_to(REPO_ROOT)))
+            touched_files.append(str(lock.relative_to(root)))
         return "lock-failed"
-    touched_files.append(str(lock.relative_to(REPO_ROOT)))
+    lock_log.unlink(missing_ok=True)
+    touched_files.append(str(lock.relative_to(root)))
 
     if plugin in SKIP_TESTS:
-        print(f"skip: [{plugin}] integration tests skipped (matches CI)")
+        print(f"[{now()}] [{plugin}] skipped (matches CI)")
         return "skipped"
 
     integration_dir = plugin_dir / "integration"
     if not (integration_dir / "docker-compose.yml").exists():
-        print(f"skip: [{plugin}] no integration/docker-compose.yml")
+        print(f"[{now()}] [{plugin}] skip: no integration/docker-compose.yml")
         return "no-integration-tests"
 
     # init-network.sh (only used by cache_redis) exports a randomized SUBNET/
@@ -173,26 +324,48 @@ def test_plugin(plugin: str, version: str, touched_files: list[str]) -> str:
     init_network = integration_dir / "init-network.sh"
     build_env = env_from_sourced_script(init_network) if init_network.exists() else dict(os.environ)
 
-    print(f"== [{plugin}] docker compose build ==")
-    if run(["docker", "compose", "build"], cwd=integration_dir, env=build_env) != 0:
-        print(f"FAIL: [{plugin}] docker compose build failed")
+    build_log = log_dir / f"{plugin}-build.log"
+    if run_logged(["docker", "compose", "build"], cwd=integration_dir, log_path=build_log, env=build_env) != 0:
+        log_failure(f"{plugin} docker compose build output", log_path=build_log)
+        print(f"[{now()}] [{plugin}] FAILED: docker compose build -- details in {RUN_LOG_PATH.name}")
+        build_log.unlink(missing_ok=True)
         compose_down(integration_dir)
+        if init_network.exists():
+            remove_standalone_network("acapy_default")
         return "build-failed"
+    # Build succeeded -- from here only the test run itself matters.
+    build_log.unlink(missing_ok=True)
 
-    print(f"== [{plugin}] running integration tests ==")
+    test_log = log_dir / f"{plugin}-test.log"
     if plugin == "cache_redis":
-        test_exit = run(["docker", "compose", "up", "-d"], cwd=integration_dir)
+        test_exit = run_logged(["docker", "compose", "up", "-d"], cwd=integration_dir, log_path=test_log)
         if test_exit == 0:
-            test_exit = run(["docker", "compose", "run", "--rm", "tests"], cwd=integration_dir)
+            test_exit = run_logged(
+                ["docker", "compose", "run", "--rm", "tests"],
+                cwd=integration_dir,
+                log_path=test_log,
+                mode="a",
+            )
     else:
-        test_exit = run(
+        test_exit = run_logged(
             ["docker", "compose", "up", "--exit-code-from", "tests"],
             cwd=integration_dir,
+            log_path=test_log,
         )
 
     compose_down(integration_dir)
+    if init_network.exists():
+        remove_standalone_network("acapy_default")
 
-    return "pass" if test_exit == 0 else "fail"
+    if test_exit != 0:
+        log_failure(f"{plugin} integration test output", log_path=test_log)
+        print(f"[{now()}] [{plugin}] FAILED: integration tests -- details in {RUN_LOG_PATH.name}")
+        test_log.unlink(missing_ok=True)
+        return "fail"
+
+    test_log.unlink(missing_ok=True)
+    print(f"[{now()}] [{plugin}] PASSED")
+    return "pass"
 
 
 def main() -> None:
@@ -203,24 +376,56 @@ def main() -> None:
     parser.add_argument(
         "plugins", nargs="*", help="Plugins to test (default: all discovered plugins)"
     )
+    parser.add_argument(
+        "--tag",
+        metavar="REF",
+        help=(
+            "Test against this git tag/ref instead of the current checkout "
+            "(e.g. the most recent tag for an ACA-Py LTS line), checked out "
+            "into a temporary worktree. Leaves the current working tree untouched."
+        ),
+    )
     args = parser.parse_args()
 
-    os.chdir(REPO_ROOT)
-    check_clean()
+    RUN_LOG_PATH.write_text(
+        f"test_acapy_version.py run -- {datetime.datetime.now().isoformat(timespec='seconds')}\n"
+        f"acapy-agent version: {args.version}\n"
+        + (f"tag: {args.tag}\n" if args.tag else "")
+    )
+    print(f"Full output on failure will be written to {RUN_LOG_PATH.name}")
 
-    all_plugins = discover_plugins()
-    plugins = args.plugins or all_plugins
+    root = REPO_ROOT
+    worktree_path: Path | None = None
+    if args.tag:
+        worktree_path = create_worktree(args.tag)
+        root = worktree_path
 
-    touched_files: list[str] = []
-    results: dict[str, str] = {}
+    log_dir = Path(tempfile.mkdtemp(prefix="test-acapy-version-logs-"))
     try:
-        for plugin in plugins:
-            results[plugin] = test_plugin(plugin, args.version, touched_files)
+        os.chdir(root)
+        check_clean(root)
+
+        all_plugins = discover_plugins(root)
+        plugins = args.plugins or all_plugins
+
+        touched_files: list[str] = []
+        results: dict[str, str] = {}
+        try:
+            for plugin in plugins:
+                results[plugin] = test_plugin(
+                    plugin, args.version, touched_files, root, log_dir, bool(args.tag)
+                )
+        finally:
+            revert(touched_files, root)
     finally:
-        revert(touched_files)
+        shutil.rmtree(log_dir, ignore_errors=True)
+        os.chdir(REPO_ROOT)
+        if worktree_path:
+            remove_worktree(worktree_path)
 
     print()
-    print(f"================ Summary (acapy-agent {args.version}) ================")
+    tag_suffix = f", tag {args.tag}" if args.tag else ""
+    print(f"================ Summary (acapy-agent {args.version}{tag_suffix}) ================")
     for plugin in plugins:
         print(f"{plugin:<30} {results.get(plugin, 'not-run')}")
 


### PR DESCRIPTION
Improves the recently added `test_acapy_version.py` script to add support for testing LTS releases. To do that, added a `--tag 1.3.2` option so that when testing an LTS, the Plugins used are those "in play" at the time of the last main branch release of the LTS. This improves the chance of the test containers building (no lock dependency resolution failures) and the plugin code matching that of the LTS release.

Also improved was the logging. Logging is not sent to stdout but instead to a file per plugin. If the plugin tests pass the log file is just deleted, if they fail the log file is  added to a file (`.test_acapy_version.log` that survives the test (and .gitignored).

Also added some handling of lock file fails for specific dependencies when using old tags. See readme and the script for details of how that might fix lock fails during builds.

README.md documentation about the script updated.



Signed-off-by: Stephen Curran <swcurran@gmail.com>
